### PR TITLE
Move balance scoring to the RPi and add reusable activity framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ SRCS := \
 	SonicSole_Core.cpp \
 	SonicSole_Pressure.cpp \
 	SonicSole_IMU.cpp \
-	SonicSole_UDP.cpp
+	SonicSole_UDP.cpp \
+	SonicSole_Activity.cpp
 OBJS := $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(SRCS))
 DEPS := $(OBJS:.o=.d)
 
@@ -21,7 +22,7 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CXX) $(OBJS) -o $@ $(LDLIBS)
 
-$(BUILD_DIR)/%.o: %.cpp SonicSole.h RPi_combined_Header.h RPi_Raj_Header.h
+$(BUILD_DIR)/%.o: %.cpp SonicSole.h SonicSole_Activity.h RPi_combined_Header.h RPi_Raj_Header.h
 	@mkdir -p $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 

--- a/SonicSole_Activity.cpp
+++ b/SonicSole_Activity.cpp
@@ -1,0 +1,446 @@
+#include "SonicSole_Activity.h"
+
+#include <algorithm>
+#include <arpa/inet.h>
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <sys/socket.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr std::size_t kCommandBufferSize = 512;
+constexpr int kMaxCommandsPerTick = 8;
+
+std::string trimCopy(const std::string& input)
+{
+    auto isNotSpace = [](unsigned char ch) { return !std::isspace(ch); };
+    const auto beginIt = std::find_if(input.begin(), input.end(), isNotSpace);
+    const auto endIt = std::find_if(input.rbegin(), input.rend(), isNotSpace).base();
+    if (beginIt >= endIt) {
+        return {};
+    }
+    return std::string(beginIt, endIt);
+}
+
+std::vector<std::string> splitWhitespace(const std::string& input)
+{
+    std::vector<std::string> tokens;
+    std::istringstream stream(input);
+    std::string token;
+    while (stream >> token) {
+        tokens.push_back(token);
+    }
+    return tokens;
+}
+
+std::string upper(const std::string& input)
+{
+    std::string output = input;
+    for (char& ch : output) {
+        ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+    }
+    return output;
+}
+
+int currentPeakPressure(const SonicSole& sole)
+{
+    const int heel = static_cast<int>(sole.currHeelPressure);
+    const int fore = static_cast<int>(sole.currForePressure);
+    return heel > fore ? heel : fore;
+}
+
+int readEnvInt(const char* name, int fallback)
+{
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') {
+        return fallback;
+    }
+    char* endPtr = nullptr;
+    const long parsed = std::strtol(value, &endPtr, 10);
+    if (endPtr == value || *endPtr != '\0') {
+        return fallback;
+    }
+    return static_cast<int>(parsed);
+}
+
+double readEnvDouble(const char* name, double fallback)
+{
+    const char* value = std::getenv(name);
+    if (value == nullptr || *value == '\0') {
+        return fallback;
+    }
+    char* endPtr = nullptr;
+    const double parsed = std::strtod(value, &endPtr);
+    if (endPtr == value || *endPtr != '\0') {
+        return fallback;
+    }
+    return parsed;
+}
+
+std::string formatClient(const struct sockaddr_in& addr)
+{
+    char buffer[INET_ADDRSTRLEN] = {};
+    inet_ntop(AF_INET, &addr.sin_addr, buffer, sizeof(buffer));
+    std::ostringstream stream;
+    stream << buffer << ':' << ntohs(addr.sin_port);
+    return stream.str();
+}
+
+} // namespace
+
+// BalanceActivity ---------------------------------------------------------
+
+BalanceActivity::BalanceActivity()
+{
+    threshold = readEnvInt("SONICSOLE_BALANCE_THRESHOLD", threshold);
+    liftWaitSec = readEnvDouble("SONICSOLE_BALANCE_LIFT_WAIT", liftWaitSec);
+    maxDurationSec = readEnvDouble("SONICSOLE_BALANCE_MAX_DURATION", maxDurationSec);
+}
+
+void BalanceActivity::onStart(SonicSole& /*sole*/)
+{
+    phase_ = Phase::WaitLift;
+    phaseStartMicros_ = getMicrosTimeStamp();
+    liftMicros_ = 0;
+    std::cout << "[Activity] balance started, waiting for foot lift"
+              << " (threshold=" << threshold
+              << ", lift_wait=" << liftWaitSec << "s"
+              << ", max_duration=" << maxDurationSec << "s)"
+              << std::endl;
+}
+
+bool BalanceActivity::onStep(SonicSole& sole, ActivityResult& result)
+{
+    const int peak = currentPeakPressure(sole);
+    const std::uint64_t nowMicros = getMicrosTimeStamp();
+
+    if (phase_ == Phase::WaitLift) {
+        const double elapsedSec = static_cast<double>(nowMicros - phaseStartMicros_) / 1e6;
+        if (peak < threshold) {
+            liftMicros_ = nowMicros;
+            phase_ = Phase::Timing;
+            std::cout << "[Activity] balance: foot lifted after "
+                      << elapsedSec << "s, timing" << std::endl;
+            return false;
+        }
+        if (elapsedSec > liftWaitSec) {
+            result.activityName = name();
+            result.success = false;
+            result.reason = "lift_timeout";
+            std::cout << "[Activity] balance: lift timeout after "
+                      << elapsedSec << "s" << std::endl;
+            return true;
+        }
+        return false;
+    }
+
+    const double elapsedSec = static_cast<double>(nowMicros - liftMicros_) / 1e6;
+    if (peak >= threshold) {
+        result.activityName = name();
+        result.success = true;
+        result.score = elapsedSec;
+        result.reason.clear();
+        std::cout << "[Activity] balance: foot replanted, score="
+                  << elapsedSec << "s (peak=" << peak << ")" << std::endl;
+        return true;
+    }
+    if (elapsedSec >= maxDurationSec) {
+        result.activityName = name();
+        result.success = true;
+        result.score = elapsedSec;
+        result.reason = "max_duration";
+        std::cout << "[Activity] balance: max duration reached, score="
+                  << elapsedSec << "s" << std::endl;
+        return true;
+    }
+    return false;
+}
+
+void BalanceActivity::onCancel(SonicSole& /*sole*/, ActivityResult& result)
+{
+    result.activityName = name();
+    result.success = false;
+    result.reason = "cancelled";
+    phase_ = Phase::WaitLift;
+}
+
+// ActivityManager ---------------------------------------------------------
+
+ActivityManager::ActivityManager() = default;
+
+ActivityManager::~ActivityManager()
+{
+    stop();
+}
+
+const std::string& ActivityManager::activeActivityName() const
+{
+    static const std::string empty;
+    return currentActivity_ != nullptr ? currentActivity_->name() : empty;
+}
+
+void ActivityManager::registerActivity(std::unique_ptr<ActivityBase> activity)
+{
+    if (!activity) {
+        return;
+    }
+    if (findActivity(activity->name()) != nullptr) {
+        std::cerr << "[Activity] Ignoring duplicate registration for '"
+                  << activity->name() << "'" << std::endl;
+        return;
+    }
+    std::cout << "[Activity] Registered activity '" << activity->name() << "'" << std::endl;
+    activities_.push_back(std::move(activity));
+}
+
+bool ActivityManager::start(int listenPort)
+{
+    stop();
+    listenPort_ = listenPort;
+
+    listenSock_ = socket(AF_INET, SOCK_DGRAM, 0);
+    if (listenSock_ == -1) {
+        std::cerr << "[Activity] Failed to create control socket: "
+                  << std::strerror(errno) << std::endl;
+        return false;
+    }
+
+    int reuse = 1;
+    setsockopt(listenSock_, SOL_SOCKET, SO_REUSEADDR, &reuse, sizeof(reuse));
+
+    const int flags = fcntl(listenSock_, F_GETFL, 0);
+    if (flags == -1 || fcntl(listenSock_, F_SETFL, flags | O_NONBLOCK) == -1) {
+        std::cerr << "[Activity] Failed to set non-blocking control socket: "
+                  << std::strerror(errno) << std::endl;
+        close(listenSock_);
+        listenSock_ = -1;
+        return false;
+    }
+
+    struct sockaddr_in addr {};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(listenPort));
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+
+    if (bind(listenSock_, reinterpret_cast<const struct sockaddr*>(&addr), sizeof(addr)) == -1) {
+        std::cerr << "[Activity] Failed to bind control socket on port "
+                  << listenPort << ": " << std::strerror(errno) << std::endl;
+        close(listenSock_);
+        listenSock_ = -1;
+        return false;
+    }
+
+    std::cout << "[Activity] Listening for commands on UDP " << listenPort << std::endl;
+    return true;
+}
+
+void ActivityManager::stop()
+{
+    if (listenSock_ != -1) {
+        close(listenSock_);
+        listenSock_ = -1;
+    }
+    currentActivity_ = nullptr;
+    hasClient_ = false;
+}
+
+ActivityBase* ActivityManager::findActivity(const std::string& name)
+{
+    for (auto& activity : activities_) {
+        if (activity->name() == name) {
+            return activity.get();
+        }
+    }
+    return nullptr;
+}
+
+void ActivityManager::tick(SonicSole& sole)
+{
+    pollCommands(sole);
+
+    if (currentActivity_ == nullptr) {
+        return;
+    }
+
+    ActivityResult result;
+    if (currentActivity_->onStep(sole, result)) {
+        if (hasClient_) {
+            sendResult(result, currentClient_);
+        }
+        currentActivity_ = nullptr;
+        hasClient_ = false;
+    }
+}
+
+void ActivityManager::pollCommands(SonicSole& sole)
+{
+    if (listenSock_ == -1) {
+        return;
+    }
+
+    char buffer[kCommandBufferSize];
+    for (int i = 0; i < kMaxCommandsPerTick; ++i) {
+        struct sockaddr_in sender {};
+        socklen_t senderLen = sizeof(sender);
+        const ssize_t received = recvfrom(
+            listenSock_, buffer, sizeof(buffer) - 1, 0,
+            reinterpret_cast<struct sockaddr*>(&sender), &senderLen);
+        if (received <= 0) {
+            return;
+        }
+
+        buffer[received] = '\0';
+        const std::string command = trimCopy(std::string(buffer, static_cast<std::size_t>(received)));
+        if (command.empty()) {
+            continue;
+        }
+
+        std::cout << "[Activity] Received command '" << command
+                  << "' from " << formatClient(sender) << std::endl;
+
+        const auto tokens = splitWhitespace(command);
+        if (tokens.empty()) {
+            continue;
+        }
+
+        const std::string verb = upper(tokens[0]);
+        const std::string activityName = tokens.size() >= 2 ? tokens[1] : std::string();
+
+        if (verb == "START") {
+            if (activityName.empty()) {
+                ActivityResult err;
+                err.activityName = "unknown";
+                err.reason = "missing_activity";
+                sendResult(err, sender);
+                continue;
+            }
+            handleStart(sole, activityName, sender);
+        } else if (verb == "CANCEL" || verb == "STOP") {
+            handleCancel(sole, activityName, sender);
+        } else if (verb == "PING") {
+            handlePing(activityName, sender);
+        } else {
+            ActivityResult err;
+            err.activityName = activityName.empty() ? "unknown" : activityName;
+            err.reason = "unknown_verb";
+            sendResult(err, sender);
+        }
+    }
+}
+
+void ActivityManager::handleStart(
+    SonicSole& sole,
+    const std::string& activityName,
+    const struct sockaddr_in& sender)
+{
+    ActivityBase* activity = findActivity(activityName);
+    if (activity == nullptr) {
+        ActivityResult err;
+        err.activityName = activityName;
+        err.reason = "unknown_activity";
+        sendResult(err, sender);
+        return;
+    }
+
+    if (currentActivity_ != nullptr) {
+        ActivityResult cancelResult;
+        currentActivity_->onCancel(sole, cancelResult);
+        if (hasClient_) {
+            sendResult(cancelResult, currentClient_);
+        }
+    }
+
+    currentActivity_ = activity;
+    currentClient_ = sender;
+    hasClient_ = true;
+    activity->onStart(sole);
+}
+
+void ActivityManager::handleCancel(
+    SonicSole& sole,
+    const std::string& activityName,
+    const struct sockaddr_in& sender)
+{
+    if (currentActivity_ == nullptr) {
+        ActivityResult err;
+        err.activityName = activityName.empty() ? "unknown" : activityName;
+        err.reason = "not_running";
+        sendResult(err, sender);
+        return;
+    }
+
+    if (!activityName.empty() && currentActivity_->name() != activityName) {
+        ActivityResult err;
+        err.activityName = activityName;
+        err.reason = "activity_mismatch";
+        sendResult(err, sender);
+        return;
+    }
+
+    ActivityResult runningResult;
+    currentActivity_->onCancel(sole, runningResult);
+    if (hasClient_) {
+        sendResult(runningResult, currentClient_);
+    }
+
+    ActivityResult ack;
+    ack.activityName = currentActivity_->name();
+    ack.success = true;
+    ack.reason = "cancelled";
+    sendResult(ack, sender);
+
+    currentActivity_ = nullptr;
+    hasClient_ = false;
+}
+
+void ActivityManager::handlePing(
+    const std::string& activityName,
+    const struct sockaddr_in& sender)
+{
+    ActivityResult pong;
+    pong.success = true;
+    pong.activityName = activityName.empty() ? "ping" : activityName;
+    pong.score = 0.0;
+    pong.reason = "pong";
+    sendResult(pong, sender);
+}
+
+void ActivityManager::sendResult(const ActivityResult& result, const struct sockaddr_in& client)
+{
+    if (listenSock_ == -1) {
+        return;
+    }
+
+    std::ostringstream message;
+    if (result.success) {
+        message << "OK " << result.activityName << ' '
+                << std::fixed << std::setprecision(4) << result.score;
+        if (!result.reason.empty()) {
+            message << ' ' << result.reason;
+        }
+    } else {
+        message << "ERR "
+                << (result.activityName.empty() ? "unknown" : result.activityName) << ' '
+                << (result.reason.empty() ? "unknown" : result.reason);
+    }
+
+    const std::string payload = message.str();
+    const ssize_t sent = sendto(
+        listenSock_, payload.data(), payload.size(), 0,
+        reinterpret_cast<const struct sockaddr*>(&client), sizeof(client));
+
+    if (sent == -1) {
+        std::cerr << "[Activity] Failed to send result to "
+                  << formatClient(client) << ": " << std::strerror(errno) << std::endl;
+    } else {
+        std::cout << "[Activity] Sent '" << payload << "' to "
+                  << formatClient(client) << std::endl;
+    }
+}

--- a/SonicSole_Activity.h
+++ b/SonicSole_Activity.h
@@ -1,0 +1,81 @@
+#ifndef SONICSOLE_ACTIVITY_H
+#define SONICSOLE_ACTIVITY_H
+
+#include "SonicSole.h"
+
+#include <cstdint>
+#include <memory>
+#include <netinet/in.h>
+#include <string>
+#include <vector>
+
+struct ActivityResult {
+    bool success = false;
+    std::string activityName;
+    double score = 0.0;
+    std::string reason;
+};
+
+class ActivityBase {
+public:
+    virtual ~ActivityBase() = default;
+    virtual const std::string& name() const = 0;
+    virtual void onStart(SonicSole& sole) = 0;
+    virtual bool onStep(SonicSole& sole, ActivityResult& result) = 0;
+    virtual void onCancel(SonicSole& sole, ActivityResult& result) = 0;
+};
+
+class BalanceActivity : public ActivityBase {
+public:
+    BalanceActivity();
+    const std::string& name() const override { return kName; }
+    void onStart(SonicSole& sole) override;
+    bool onStep(SonicSole& sole, ActivityResult& result) override;
+    void onCancel(SonicSole& sole, ActivityResult& result) override;
+
+    int threshold = 100;
+    double liftWaitSec = 30.0;
+    double maxDurationSec = 120.0;
+
+private:
+    enum class Phase { WaitLift, Timing };
+    const std::string kName = "balance";
+    Phase phase_ = Phase::WaitLift;
+    std::uint64_t phaseStartMicros_ = 0;
+    std::uint64_t liftMicros_ = 0;
+};
+
+class ActivityManager {
+public:
+    ActivityManager();
+    ~ActivityManager();
+
+    ActivityManager(const ActivityManager&) = delete;
+    ActivityManager& operator=(const ActivityManager&) = delete;
+
+    void registerActivity(std::unique_ptr<ActivityBase> activity);
+    bool start(int listenPort);
+    void stop();
+    void tick(SonicSole& sole);
+
+    bool hasActiveActivity() const { return currentActivity_ != nullptr; }
+    const std::string& activeActivityName() const;
+
+private:
+    int listenSock_ = -1;
+    int listenPort_ = 0;
+
+    std::vector<std::unique_ptr<ActivityBase>> activities_;
+    ActivityBase* currentActivity_ = nullptr;
+    struct sockaddr_in currentClient_ {};
+    bool hasClient_ = false;
+
+    ActivityBase* findActivity(const std::string& name);
+    void pollCommands(SonicSole& sole);
+    void sendResult(const ActivityResult& result, const struct sockaddr_in& client);
+    void handleStart(SonicSole& sole, const std::string& activityName, const struct sockaddr_in& sender);
+    void handleCancel(SonicSole& sole, const std::string& activityName, const struct sockaddr_in& sender);
+    void handlePing(const std::string& activityName, const struct sockaddr_in& sender);
+};
+
+#endif // SONICSOLE_ACTIVITY_H

--- a/SonicSole_RPi.cpp
+++ b/SonicSole_RPi.cpp
@@ -1,11 +1,33 @@
 #include "SonicSole.h"
+#include "SonicSole_Activity.h"
 
 #include <chrono>
+#include <cstdlib>
 #include <iostream>
+#include <memory>
 #include <sys/time.h>
 #include <vector>
 
 namespace {
+
+constexpr int kDefaultActivityPort = 21010;
+const char* const kActivityPortEnv = "SONICSOLE_ACTIVITY_PORT";
+
+int resolveActivityPort()
+{
+    const char* raw = std::getenv(kActivityPortEnv);
+    if (raw == nullptr || *raw == '\0') {
+        return kDefaultActivityPort;
+    }
+    char* endPtr = nullptr;
+    const long parsed = std::strtol(raw, &endPtr, 10);
+    if (endPtr == raw || *endPtr != '\0' || parsed <= 0 || parsed > 65535) {
+        std::cerr << "Ignoring invalid " << kActivityPortEnv << "=" << raw
+                  << ", falling back to " << kDefaultActivityPort << std::endl;
+        return kDefaultActivityPort;
+    }
+    return static_cast<int>(parsed);
+}
 
 void sendCurrentSensorPacket(SonicSole& sole)
 {
@@ -26,10 +48,20 @@ void sendCurrentSensorPacket(SonicSole& sole)
 
 } // namespace
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* /*argv*/[])
 {
     SonicSole sole;
     std::cout << "SonicSole Class Initialized" << std::endl;
+
+    ActivityManager activityManager;
+    activityManager.registerActivity(std::make_unique<BalanceActivity>());
+    // Add more activities here (jump, reaction, precision) by registering
+    // additional subclasses of ActivityBase. The command/response protocol
+    // and client wiring in the webapp are shared across activities.
+    if (!activityManager.start(resolveActivityPort())) {
+        std::cerr << "Activity control listener disabled; sensor streaming only."
+                  << std::endl;
+    }
 
     sole.openCSVFile();
 
@@ -81,6 +113,13 @@ int main(int argc, char* argv[])
         std::cout << "IMU Data (g) (ax, ay, az): "
                   << sole.ax << ", " << sole.ay << ", " << sole.az << std::endl;
         std::cout << "IMU Packet Preview: " << sole.imuPacketPreview << std::endl;
+
+        if (activityManager.hasActiveActivity()) {
+            std::cout << "Activity: " << activityManager.activeActivityName()
+                      << " in progress" << std::endl;
+        }
+
+        activityManager.tick(sole);
 
         sendCurrentSensorPacket(sole);
     }

--- a/web_page/app.py
+++ b/web_page/app.py
@@ -924,12 +924,16 @@ def probe_hardware_device(group):
 
 #UDP_IP = "127.0.0.1" #accept data from localhost
 UDP_IP = "0.0.0.0" # accept connections on any available network interface of the server
-UDP_PORT = 21000 
+UDP_PORT = 21000
 DISCOVERY_PORT = int(os.environ.get("SONICSOLE_DISCOVERY_PORT", "21001"))
 DISCOVERY_REQUEST = b"SONICSOLE_DISCOVER_SERVER_V1"
 DISCOVERY_RESPONSE = b"SONICSOLE_SERVER_V1"
 DISCOVERY_BUFFER_SIZE = 256
 bufferSize = 1024
+
+ACTIVITY_COMMAND_PORT = int(os.environ.get("SONICSOLE_ACTIVITY_PORT", "21010"))
+ACTIVITY_COMMAND_TIMEOUT_SECONDS = float(os.environ.get("SONICSOLE_ACTIVITY_TIMEOUT", "180.0"))
+ACTIVITY_RESPONSE_BUFFER_SIZE = 1024
 
 udp_queue = queue.Queue(maxsize=1) #hold latest packet only
 
@@ -1083,12 +1087,34 @@ def get_balance_session_id():
 
 def cancel_balance_session():
     global totalTime, recording_time, received_heel_data, received_fore_data
+    was_recording = recording_time
     cancel_activity_session("balance")
     recording_time = False
     totalTime = "0"
     received_heel_data = "0"
     received_fore_data = "0"
     stop_combined_data_thread()
+    try:
+        set_balance_status("idle")
+    except NameError:
+        pass
+    if was_recording:
+        cancel_device_ip = resolve_activity_device_ip()
+        if cancel_device_ip:
+            threading.Thread(
+                target=_send_activity_command_fire_and_forget,
+                args=(cancel_device_ip, "CANCEL balance"),
+                daemon=True,
+            ).start()
+
+
+def _send_activity_command_fire_and_forget(device_ip, command):
+    try:
+        send_rpi_activity_command(device_ip, command, timeout_seconds=2.0)
+    except ActivityCommandError:
+        pass
+    except Exception:
+        pass
 
 
 def create_activity_session(activity_name):
@@ -1191,6 +1217,87 @@ def stop_all_activities():
     G_heel = 255
     R_fore = 0
     G_fore = 255
+
+
+class ActivityCommandError(Exception):
+    def __init__(self, reason, detail=""):
+        super().__init__(detail or reason)
+        self.reason = reason
+        self.detail = detail
+
+
+def send_rpi_activity_command(device_ip, command, timeout_seconds=ACTIVITY_COMMAND_TIMEOUT_SECONDS):
+    """Send a command to the RPi activity listener and block for the reply.
+
+    Parses responses of the form "OK <activity> <score> [reason]" or
+    "ERR <activity> <reason>" and returns a dict describing the outcome:
+
+        {"success": bool, "activity": str, "score": float|None, "reason": str}
+
+    Raises ActivityCommandError on network or protocol failures.
+    """
+    if not device_ip:
+        raise ActivityCommandError("no_device", "no RPi device ip available")
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.settimeout(max(0.5, timeout_seconds))
+        try:
+            sock.sendto(command.encode("utf-8"), (device_ip, ACTIVITY_COMMAND_PORT))
+        except OSError as send_error:
+            raise ActivityCommandError("send_failed", str(send_error)) from send_error
+        try:
+            payload, _ = sock.recvfrom(ACTIVITY_RESPONSE_BUFFER_SIZE)
+        except socket.timeout as timeout_error:
+            raise ActivityCommandError("timeout", "no reply from RPi") from timeout_error
+        except OSError as recv_error:
+            raise ActivityCommandError("recv_failed", str(recv_error)) from recv_error
+    finally:
+        sock.close()
+
+    response_text = payload.decode("utf-8", errors="replace").strip()
+    if not response_text:
+        raise ActivityCommandError("empty_reply", "RPi returned empty response")
+
+    tokens = response_text.split()
+    status = tokens[0].upper()
+    activity_name = tokens[1] if len(tokens) >= 2 else ""
+
+    if status == "OK":
+        score_value = None
+        if len(tokens) >= 3:
+            try:
+                score_value = float(tokens[2])
+            except ValueError as parse_error:
+                raise ActivityCommandError("bad_score", response_text) from parse_error
+        reason = " ".join(tokens[3:]) if len(tokens) > 3 else ""
+        return {
+            "success": True,
+            "activity": activity_name,
+            "score": score_value,
+            "reason": reason,
+        }
+
+    if status == "ERR":
+        reason = " ".join(tokens[2:]) if len(tokens) > 2 else "unknown"
+        return {
+            "success": False,
+            "activity": activity_name,
+            "score": None,
+            "reason": reason,
+        }
+
+    raise ActivityCommandError("bad_response", response_text)
+
+
+def resolve_activity_device_ip():
+    device_ip = get_active_device_ip()
+    if device_ip:
+        return device_ip
+    selected_group = get_selected_group()
+    if selected_group and selected_group.get("ip"):
+        return selected_group["ip"]
+    return None
 
 
 def normalize_quaternion(x_value, y_value, z_value, w_value):
@@ -1805,51 +1912,53 @@ def jump_metrics():
     })
 
 # balance
-def balancing_pressure(session_id):
-    global totalTime, submitted_name, recording_time, received_heel_data, received_fore_data, threshold_heel, threshold_fore
-    print("[balancing_pressure] Called")
-    received_heel_data = "0"
-    received_fore_data = "0"
-    totalTime = "0"
-    start_combined_data_thread()
-    print("[balancing_pressure] balance_started")
-    start_time = None
-    start_delay_period = 0.5 #gives grace period so repeated runs are possible 
-    start = time.time()
-    while True:
-        if session_id != get_balance_session_id():
-            break
-        now = time.time()
-        if recording_time:
-            if start_time is None:
-                start_time = now
-            if now - start < start_delay_period:
-                time.sleep(0.01)
-                continue
-            heel = int(received_heel_data)
-            fore = int(received_fore_data)
+balance_status = {
+    "status": "idle",
+    "reason": "",
+}
 
-            if heel < threshold_heel and fore < threshold_fore:
-                totalTime = "{:.3f}".format(now - start_time)
-            else:
-                recording_time = False
-                print("[balancing_pressure] balance_stopped")
-                    
-                # with open("SonicSoleBalance.txt", "a") as f:
-                #     f.write(f"{submitted_name},{totalTime}\n")
 
-                stop_combined_data_thread()
-                break
-        else:
-            stop_combined_data_thread()
-            break
-        time.sleep(0.01)
-    print("[balancing_pressure] thread complete, combined_data_running:", combined_data_running)
+def set_balance_status(status, reason=""):
+    global balance_status
+    balance_status = {"status": status, "reason": reason or ""}
 
-# @app.route('/balancing', methods=['GET'])
-# def balancing():
-#     global totalTime
-#     return jsonify({'data': totalTime})
+
+def balancing_pressure(session_id, device_ip):
+    """Run the balance activity on the RPi and wait for the score.
+
+    Framework contract: the webapp sends START <activity> to the RPi over
+    UDP and blocks until the RPi replies with OK/ERR. All threshold
+    detection and timing happen on the RPi to avoid wireless jitter.
+    """
+    global totalTime, recording_time
+
+    print(f"[balance] sending START balance to RPi at {device_ip}")
+    set_balance_status("measuring")
+    try:
+        reply = send_rpi_activity_command(device_ip, "START balance")
+    except ActivityCommandError as command_error:
+        print(f"[balance] command failed: {command_error.reason} ({command_error.detail})")
+        if session_id == get_balance_session_id():
+            recording_time = False
+            set_balance_status("error", command_error.reason)
+        return
+
+    if session_id != get_balance_session_id():
+        print("[balance] session changed while waiting for RPi; discarding reply")
+        return
+
+    if reply["success"] and reply.get("score") is not None:
+        score_value = float(reply["score"])
+        totalTime = "{:.3f}".format(score_value)
+        recording_time = False
+        set_balance_status("done", reply.get("reason", ""))
+        print(f"[balance] score={score_value:.3f}s from RPi")
+    else:
+        reason = reply.get("reason") or "error"
+        print(f"[balance] RPi reported failure: {reason}")
+        recording_time = False
+        set_balance_status("error", reason)
+
 
 @app.route('/balancing', methods=['GET'])
 def balancing():
@@ -1858,7 +1967,12 @@ def balancing():
         done = not recording_time and float(totalTime) != 0
     except ValueError:
         done = False
-    return jsonify({'data': totalTime, 'done': done})
+    return jsonify({
+        'data': totalTime,
+        'done': done,
+        'status': balance_status.get("status", "idle"),
+        'reason': balance_status.get("reason", ""),
+    })
 
 
 @app.route('/button_click', methods=['POST'])
@@ -1867,15 +1981,29 @@ def button_click():
     _, error_response = require_selected_group()
     if error_response is not None:
         return error_response
+
+    device_ip = resolve_activity_device_ip()
+    if not device_ip:
+        return jsonify({
+            "status": "error",
+            "message": "No SonicSole device is linked to the selected group yet.",
+        }), 400
+
     session_id = create_balance_session()
+    start_combined_data_thread()
+    set_balance_status("countdown")
     CountSound.play()
-    time.sleep(3.12) #sleeps so countdown can run before timer begins
+    time.sleep(3.12)
     if session_id != get_balance_session_id():
+        set_balance_status("idle")
         return jsonify({"status": "Data transmission cancelled"})
     recording_time = True
     totalTime = "0"
-    thread = threading.Thread(target=balancing_pressure, args=(session_id,))
-    thread.daemon = True
+    thread = threading.Thread(
+        target=balancing_pressure,
+        args=(session_id, device_ip),
+        daemon=True,
+    )
     thread.start()
     return jsonify({"status": "Data transmission started"})
 

--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -201,6 +201,28 @@
       margin-top: auto;
     }
 
+    .pg-activity-status-box--compact {
+      aspect-ratio: auto !important;
+      min-height: 200px !important;
+      padding: 28px 20px !important;
+    }
+
+    .pg-activity-status-box--compact strong {
+      font-size: 1.4em;
+    }
+
+    .pg-status-stacked {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .pg-status-stacked .pg-status-sub {
+      font-size: 0.8em;
+      color: rgba(36, 50, 44, 0.72);
+    }
+
     @keyframes fadeIn {
       from { opacity: 0; transform: translateY(-10px); }
       to { opacity: 1; transform: translateY(0); }
@@ -237,6 +259,8 @@
     <div class="card pg-card pg-activity-card">
       <div class="pg-status-grid">
         {% set activity_status_id = "statusBox" %}
+        {% set activity_status_square = false %}
+        {% set activity_status_classes = "pg-activity-status-box--compact" %}
         {% include '_activity_status_box.html' %}
       </div>
 
@@ -293,7 +317,16 @@
       fetch("/balancing")
         .then((response) => response.json())
         .then((data) => {
-          if ((!balanceActivityToggle || !balanceActivityToggle.isActive()) && !data.done && String(data.data) === "0") {
+          const toggleActive = balanceActivityToggle && balanceActivityToggle.isActive();
+          if (data.status === "error") {
+            setBalanceStatusHTML(
+              `<div class="pg-status-stacked"><strong>Try again</strong><span class="pg-status-sub">${data.reason || "Measurement failed"}</span></div>`
+            );
+          } else if (data.status === "measuring") {
+            setBalanceStatusHTML(
+              `<div class="pg-status-stacked"><strong>Lift your leg!</strong><span class="pg-status-sub">Timing on the SonicSole...</span></div>`
+            );
+          } else if (!toggleActive && !data.done && String(data.data) === "0") {
             setBalanceReadyState();
           } else {
             setBalanceStatusText(data.data + " seconds");


### PR DESCRIPTION
## Summary
- Adds a reusable on-device activity framework (`ActivityBase` / `ActivityManager`) on the RPi so each game runs its own threshold detection and stopwatch locally, eliminating the webapp post-processing loop and wireless-jitter sensitivity.
- Implements the **Balancing** activity end-to-end against that framework: webapp sends `START balance` over UDP, RPi times single-leg stand on-device, RPi replies with `OK balance <seconds>`; webapp just logs the score.
- Shrinks the balance status box so the Start button and activity dock no longer overlap at phone viewports.

## What changed

**RPi — new framework** ([SonicSole_Activity.h](SonicSole_Activity.h), [SonicSole_Activity.cpp](SonicSole_Activity.cpp))
- `ActivityBase` abstract interface (`onStart` / `onStep` / `onCancel`) — each activity is a small subclass.
- `ActivityManager` opens a non-blocking UDP control socket (default port `21010`, override via `SONICSOLE_ACTIVITY_PORT`), parses `START <activity>` / `CANCEL <activity>` / `PING` commands, and replies `OK <activity> <score>` or `ERR <activity> <reason>` to the sender.
- Polled once per tick from the main loop — sensor streaming to `21000` is untouched.
- `BalanceActivity` watches peak of heel/fore pressure. Phase 1: wait for pressure below threshold (default 100, override via `SONICSOLE_BALANCE_THRESHOLD`). Phase 2: stopwatch until pressure crosses back above threshold. Score = seconds in the air. Lift-wait and max-duration caps are env-configurable.

**RPi — main loop** ([SonicSole_RPi.cpp](SonicSole_RPi.cpp), [Makefile](Makefile))
- Registers `BalanceActivity`, starts the manager, and calls `activityManager.tick(sole)` alongside the existing pressure / IMU / UDP-streaming pipeline.
- Makefile picks up the new source file and header dependency.

**Webapp** ([web_page/app.py](web_page/app.py))
- `send_rpi_activity_command(device_ip, command)` + `ActivityCommandError` + `resolve_activity_device_ip()` — generic helpers the other three games can adopt later.
- Balance handler thread now just sends `START balance` to the RPi and parses the reply into `totalTime` / `recording_time`. `/button_click` resolves the device IP from the selected group. `cancel_balance_session` fires a best-effort `CANCEL balance` so a Stop click unblocks the round-trip.
- `/balancing` now also returns a `status` field (`countdown` / `measuring` / `done` / `error`) so the UI can render progress without any Python-side timing loop.

**Balance UI** ([web_page/templates/balance.html](web_page/templates/balance.html))
- Pass `activity_status_square = false` and a `pg-activity-status-box--compact` class so the status box uses `min-height: 200px` instead of a 1:1 aspect square. This is what made the card too tall at phone viewports (the 720px media query collapsed the status grid to 1 column, turning the 475px-wide box into a 475px-tall square that shoved the Start button below the fixed dock).
- Added a `pg-status-stacked` helper so the "Lift your leg! / Timing on the SonicSole..." and "Try again / `<reason>`" messages stack on two lines inside the flex-centered status box.

## Wire protocol
```
webapp → RPi  (UDP 21010):  "START balance"
RPi    → webapp:            "OK balance 5.4821"        (success)
                            "ERR balance lift_timeout" (failure)
                            "ERR balance cancelled"
```

## Adding the other three activities later
1. Subclass `ActivityBase` on the RPi (e.g. `JumpActivity`, `ReactionActivity`, `PrecisionActivity`) and register it with `activityManager.registerActivity(...)` in `SonicSole_RPi.cpp`.
2. In the webapp, replace each `start_*` handler's timing loop with a `send_rpi_activity_command(device_ip, "START <name>")` call, same pattern as `balancing_pressure`.

## Test plan
- [x] On the RPi: `make` builds clean, `./SonicSole_RPi` logs `[Activity] Listening for commands on UDP 21010` at startup.
- [ ] On the webapp: select a group, open `/phone/group1/balance`, click Start. Expect countdown → "Lift your leg!" on the status card → foot replant → final time displayed → Submit Score form appears.
- [ ] Stop during an active run cancels cleanly (RPi logs `[Activity] balance: cancelled`, UI resets).
- [ ] Reconnect scenario: kill and restart `SonicSole_RPi`, start a new balance run — old run is superseded on the RPi by the new `START`.
- [ ] Visual regression check at phone viewport (`/phone/group1/balance`): Start button and dock no longer overlap; idle / measuring / error / done states all fit in the card.