### PR TITLE
Keep balance status box square and unmute reaction beep

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -2036,7 +2036,7 @@ def start_reaction():
             return jsonify({"status": "invalid"})
         time.sleep(0.005)
     beep = pygame.mixer.Sound("beep.wav")
-    beep.set_volume(0.0) 
+    beep.set_volume(1.0)
     beep.play()
     print("[Reaction] Beep")
     reaction_data["status"] = "timing"

--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -201,16 +201,6 @@
       margin-top: auto;
     }
 
-    .pg-activity-status-box--compact {
-      aspect-ratio: auto !important;
-      min-height: 200px !important;
-      padding: 28px 20px !important;
-    }
-
-    .pg-activity-status-box--compact strong {
-      font-size: 1.4em;
-    }
-
     .pg-status-stacked {
       display: flex;
       flex-direction: column;
@@ -259,8 +249,6 @@
     <div class="card pg-card pg-activity-card">
       <div class="pg-status-grid">
         {% set activity_status_id = "statusBox" %}
-        {% set activity_status_square = false %}
-        {% set activity_status_classes = "pg-activity-status-box--compact" %}
         {% include '_activity_status_box.html' %}
       </div>
 


### PR DESCRIPTION
## Summary
- Revert the balance status box back to the default square layout so it matches jump / reaction / precision.
- Unmute the reaction beep — it was set to `volume=0.0`, so the tone never played even though the RPi audio hardware works.

## Changes
- [web_page/templates/balance.html](web_page/templates/balance.html): drop the `activity_status_square = false` + `pg-activity-status-box--compact` overrides and the associated CSS block. The `.pg-status-stacked` helper stays so the `Lift your leg! / Timing on the SonicSole...` and `Try again / <reason>` messages still lay out on two lines inside the flex-centered box.
- [web_page/app.py](web_page/app.py): `beep.set_volume(0.0)` → `beep.set_volume(1.0)` in `/start_reaction`. `1.0` is pygame's documented maximum.

## Test plan
- [ ] On the RPi, start the Flask app and open `/phone/group1/balance`. Status card renders as a square, same as the other three activities.
- [ ] Open `/phone/group1/reaction`, click Start, wait out the 3–6 s random delay. You should hear the beep cue.
- [ ] If the beep still isn't audible, confirm the RPi system mixer isn't muted (`amixer set Master 100%`) — this PR just fixes the software-side mute.