### PR TITLE
Move reaction beep onto the RPi and drop pygame from the webapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX := g++
 CPPFLAGS := -MMD -MP
 CXXFLAGS := -std=c++17
-LDLIBS := -lwiringPi -lpthread
+LDLIBS := -lwiringPi -lpthread -lasound
 
 TARGET := SonicSole_RPi
 BUILD_DIR := build/sonicsole_rpi
@@ -11,7 +11,8 @@ SRCS := \
 	SonicSole_Pressure.cpp \
 	SonicSole_IMU.cpp \
 	SonicSole_UDP.cpp \
-	SonicSole_Activity.cpp
+	SonicSole_Activity.cpp \
+	SonicSole_Audio.cpp
 OBJS := $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(SRCS))
 DEPS := $(OBJS:.o=.d)
 
@@ -22,7 +23,7 @@ all: $(TARGET)
 $(TARGET): $(OBJS)
 	$(CXX) $(OBJS) -o $@ $(LDLIBS)
 
-$(BUILD_DIR)/%.o: %.cpp SonicSole.h SonicSole_Activity.h RPi_combined_Header.h RPi_Raj_Header.h
+$(BUILD_DIR)/%.o: %.cpp SonicSole.h SonicSole_Activity.h SonicSole_Audio.h RPi_combined_Header.h RPi_Raj_Header.h
 	@mkdir -p $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c $< -o $@
 

--- a/SonicSole_Activity.cpp
+++ b/SonicSole_Activity.cpp
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <iomanip>
 #include <iostream>
+#include <random>
 #include <sstream>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -169,6 +170,102 @@ void BalanceActivity::onCancel(SonicSole& /*sole*/, ActivityResult& result)
     result.success = false;
     result.reason = "cancelled";
     phase_ = Phase::WaitLift;
+}
+
+// ReactionActivity --------------------------------------------------------
+
+namespace {
+
+std::mt19937& reactionRng()
+{
+    static std::mt19937 engine{std::random_device{}()};
+    return engine;
+}
+
+} // namespace
+
+ReactionActivity::ReactionActivity(AudioPlayer* beepPlayer)
+    : beepPlayer_(beepPlayer)
+{
+    threshold = readEnvInt("SONICSOLE_REACTION_THRESHOLD", threshold);
+    minDelaySec = readEnvDouble("SONICSOLE_REACTION_MIN_DELAY", minDelaySec);
+    maxDelaySec = readEnvDouble("SONICSOLE_REACTION_MAX_DELAY", maxDelaySec);
+    maxReactSec = readEnvDouble("SONICSOLE_REACTION_MAX_REACT", maxReactSec);
+    if (maxDelaySec < minDelaySec) {
+        maxDelaySec = minDelaySec;
+    }
+}
+
+void ReactionActivity::onStart(SonicSole& /*sole*/)
+{
+    std::uniform_real_distribution<double> delayDist(minDelaySec, maxDelaySec);
+    plannedDelaySec_ = delayDist(reactionRng());
+
+    phase_ = Phase::WaitBeep;
+    phaseStartMicros_ = getMicrosTimeStamp();
+    beepMicros_ = 0;
+    std::cout << "[Activity] reaction started, waiting " << plannedDelaySec_
+              << "s before beep (threshold=" << threshold << ")" << std::endl;
+}
+
+bool ReactionActivity::onStep(SonicSole& sole, ActivityResult& result)
+{
+    const int peak = currentPeakPressure(sole);
+    const std::uint64_t nowMicros = getMicrosTimeStamp();
+
+    if (phase_ == Phase::WaitBeep) {
+        const double elapsedSec = static_cast<double>(nowMicros - phaseStartMicros_) / 1e6;
+        if (peak >= threshold) {
+            result.activityName = name();
+            result.success = false;
+            result.reason = "too_early";
+            std::cout << "[Activity] reaction: pressed too early after "
+                      << elapsedSec << "s" << std::endl;
+            return true;
+        }
+        if (elapsedSec >= plannedDelaySec_) {
+            if (beepPlayer_ != nullptr && beepPlayer_->isOpen()) {
+                beepMicros_ = beepPlayer_->play();
+            } else {
+                beepMicros_ = nowMicros;
+                std::cerr << "[Activity] reaction: beep player not ready; "
+                          << "using virtual start marker" << std::endl;
+            }
+            phase_ = Phase::Reacting;
+            std::cout << "[Activity] reaction: beep fired at +"
+                      << elapsedSec << "s, awaiting press" << std::endl;
+            return false;
+        }
+        return false;
+    }
+
+    const double reactSec = static_cast<double>(nowMicros - beepMicros_) / 1e6;
+    if (peak >= threshold) {
+        result.activityName = name();
+        result.success = true;
+        result.score = reactSec;
+        result.reason.clear();
+        std::cout << "[Activity] reaction: pressed after " << reactSec
+                  << "s (peak=" << peak << ")" << std::endl;
+        return true;
+    }
+    if (reactSec >= maxReactSec) {
+        result.activityName = name();
+        result.success = false;
+        result.reason = "react_timeout";
+        std::cout << "[Activity] reaction: react timeout after "
+                  << reactSec << "s" << std::endl;
+        return true;
+    }
+    return false;
+}
+
+void ReactionActivity::onCancel(SonicSole& /*sole*/, ActivityResult& result)
+{
+    result.activityName = name();
+    result.success = false;
+    result.reason = "cancelled";
+    phase_ = Phase::WaitBeep;
 }
 
 // ActivityManager ---------------------------------------------------------

--- a/SonicSole_Activity.h
+++ b/SonicSole_Activity.h
@@ -2,12 +2,15 @@
 #define SONICSOLE_ACTIVITY_H
 
 #include "SonicSole.h"
+#include "SonicSole_Audio.h"
 
 #include <cstdint>
 #include <memory>
 #include <netinet/in.h>
 #include <string>
 #include <vector>
+
+class AudioPlayer;
 
 struct ActivityResult {
     bool success = false;
@@ -43,6 +46,29 @@ private:
     Phase phase_ = Phase::WaitLift;
     std::uint64_t phaseStartMicros_ = 0;
     std::uint64_t liftMicros_ = 0;
+};
+
+class ReactionActivity : public ActivityBase {
+public:
+    explicit ReactionActivity(AudioPlayer* beepPlayer);
+    const std::string& name() const override { return kName; }
+    void onStart(SonicSole& sole) override;
+    bool onStep(SonicSole& sole, ActivityResult& result) override;
+    void onCancel(SonicSole& sole, ActivityResult& result) override;
+
+    int threshold = 350;           // pressure reading that counts as foot-down
+    double minDelaySec = 3.0;
+    double maxDelaySec = 6.0;
+    double maxReactSec = 5.0;      // give up if the user never reacts
+
+private:
+    enum class Phase { WaitBeep, Reacting };
+    const std::string kName = "reaction";
+    AudioPlayer* beepPlayer_ = nullptr;
+    Phase phase_ = Phase::WaitBeep;
+    std::uint64_t phaseStartMicros_ = 0;
+    std::uint64_t beepMicros_ = 0;
+    double plannedDelaySec_ = 0.0;
 };
 
 class ActivityManager {

--- a/SonicSole_Audio.cpp
+++ b/SonicSole_Audio.cpp
@@ -1,0 +1,267 @@
+#include "SonicSole_Audio.h"
+#include "SonicSole.h"
+
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+
+namespace {
+
+// Parses a PCM .wav file into `outSamples`. Fills channel / sample rate /
+// bits-per-sample metadata. Only 8- or 16-bit integer PCM is supported.
+bool loadPcmWav(
+    const std::string& path,
+    std::vector<std::uint8_t>& outSamples,
+    unsigned int& outChannels,
+    unsigned int& outSampleRate,
+    unsigned int& outBitsPerSample,
+    std::string& outError)
+{
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        outError = "cannot open " + path;
+        return false;
+    }
+
+    char riff[4] = {};
+    char wave[4] = {};
+    std::uint32_t chunkSize = 0;
+    file.read(riff, 4);
+    file.read(reinterpret_cast<char*>(&chunkSize), 4);
+    file.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
+        outError = "not a RIFF/WAVE file";
+        return false;
+    }
+
+    bool fmtFound = false;
+    bool dataFound = false;
+    std::uint16_t audioFormat = 0;
+    std::uint16_t channels = 0;
+    std::uint32_t sampleRate = 0;
+    std::uint16_t bitsPerSample = 0;
+
+    while (file && !dataFound) {
+        char chunkId[4] = {};
+        std::uint32_t chunkBytes = 0;
+        if (!file.read(chunkId, 4)) {
+            break;
+        }
+        if (!file.read(reinterpret_cast<char*>(&chunkBytes), 4)) {
+            break;
+        }
+
+        if (std::memcmp(chunkId, "fmt ", 4) == 0) {
+            std::uint32_t fmtRead = 0;
+            std::uint16_t blockAlign = 0;
+            std::uint32_t byteRate = 0;
+            file.read(reinterpret_cast<char*>(&audioFormat), 2);
+            file.read(reinterpret_cast<char*>(&channels), 2);
+            file.read(reinterpret_cast<char*>(&sampleRate), 4);
+            file.read(reinterpret_cast<char*>(&byteRate), 4);
+            file.read(reinterpret_cast<char*>(&blockAlign), 2);
+            file.read(reinterpret_cast<char*>(&bitsPerSample), 2);
+            fmtRead = 16;
+            if (chunkBytes > fmtRead) {
+                file.seekg(chunkBytes - fmtRead, std::ios::cur);
+            }
+            fmtFound = true;
+        } else if (std::memcmp(chunkId, "data", 4) == 0) {
+            outSamples.resize(chunkBytes);
+            file.read(reinterpret_cast<char*>(outSamples.data()), chunkBytes);
+            dataFound = true;
+        } else {
+            file.seekg(chunkBytes, std::ios::cur);
+        }
+    }
+
+    if (!fmtFound) {
+        outError = "missing fmt chunk";
+        return false;
+    }
+    if (!dataFound) {
+        outError = "missing data chunk";
+        return false;
+    }
+    if (audioFormat != 1) {
+        std::ostringstream message;
+        message << "unsupported audioFormat=" << audioFormat << " (only PCM is handled)";
+        outError = message.str();
+        return false;
+    }
+    if (bitsPerSample != 16 && bitsPerSample != 8) {
+        std::ostringstream message;
+        message << "unsupported bitsPerSample=" << bitsPerSample;
+        outError = message.str();
+        return false;
+    }
+
+    outChannels = channels;
+    outSampleRate = sampleRate;
+    outBitsPerSample = bitsPerSample;
+    return true;
+}
+
+} // namespace
+
+AudioPlayer::AudioPlayer() = default;
+
+AudioPlayer::~AudioPlayer()
+{
+    close();
+}
+
+bool AudioPlayer::loadAndOpen(const std::string& wavPath, const std::string& alsaDevice)
+{
+    close();
+
+    std::string loadError;
+    if (!loadPcmWav(wavPath, samples_, channels_, sampleRate_, bitsPerSample_, loadError)) {
+        lastError_ = "loadPcmWav: " + loadError;
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        return false;
+    }
+
+    format_ = (bitsPerSample_ == 16) ? SND_PCM_FORMAT_S16_LE : SND_PCM_FORMAT_U8;
+    const unsigned int frameBytes = channels_ * (bitsPerSample_ / 8);
+    if (frameBytes == 0) {
+        lastError_ = "invalid frame size computed from WAV header";
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        return false;
+    }
+    frames_ = samples_.size() / frameBytes;
+
+    int openErr = snd_pcm_open(&pcm_, alsaDevice.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
+    if (openErr < 0) {
+        lastError_ = std::string("snd_pcm_open(") + alsaDevice + "): " + snd_strerror(openErr);
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        pcm_ = nullptr;
+        return false;
+    }
+
+    snd_pcm_hw_params_t* params = nullptr;
+    snd_pcm_hw_params_alloca(&params);
+    snd_pcm_hw_params_any(pcm_, params);
+    snd_pcm_hw_params_set_access(pcm_, params, SND_PCM_ACCESS_RW_INTERLEAVED);
+    snd_pcm_hw_params_set_format(pcm_, params, format_);
+    snd_pcm_hw_params_set_channels(pcm_, params, channels_);
+    unsigned int requestedRate = sampleRate_;
+    snd_pcm_hw_params_set_rate_near(pcm_, params, &requestedRate, nullptr);
+    sampleRate_ = requestedRate;
+
+    // Small buffer keeps "write returns" close to "sound is audible".
+    snd_pcm_uframes_t bufferFrames = 2048;
+    snd_pcm_hw_params_set_buffer_size_near(pcm_, params, &bufferFrames);
+    snd_pcm_uframes_t periodFrames = 512;
+    snd_pcm_hw_params_set_period_size_near(pcm_, params, &periodFrames, nullptr);
+
+    int paramsErr = snd_pcm_hw_params(pcm_, params);
+    if (paramsErr < 0) {
+        lastError_ = std::string("snd_pcm_hw_params: ") + snd_strerror(paramsErr);
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        snd_pcm_close(pcm_);
+        pcm_ = nullptr;
+        return false;
+    }
+
+    std::cout << "[Audio] Ready: " << wavPath
+              << " (" << sampleRate_ << " Hz, "
+              << channels_ << " ch, "
+              << bitsPerSample_ << "-bit, "
+              << frames_ << " frames) on " << alsaDevice
+              << std::endl;
+
+    stopping_ = false;
+    playPending_ = false;
+    worker_ = std::thread(&AudioPlayer::workerLoop, this);
+    return true;
+}
+
+void AudioPlayer::close()
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopping_ = true;
+        playPending_ = false;
+    }
+    cv_.notify_all();
+    if (worker_.joinable()) {
+        worker_.join();
+    }
+    if (pcm_ != nullptr) {
+        snd_pcm_close(pcm_);
+        pcm_ = nullptr;
+    }
+    samples_.clear();
+}
+
+std::uint64_t AudioPlayer::play()
+{
+    const std::uint64_t ts = getMicrosTimeStamp();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        playPending_ = true;
+    }
+    cv_.notify_one();
+    return ts;
+}
+
+void AudioPlayer::workerLoop()
+{
+    while (true) {
+        std::unique_lock<std::mutex> lock(mutex_);
+        cv_.wait(lock, [this] { return playPending_ || stopping_.load(); });
+        if (stopping_.load()) {
+            return;
+        }
+        playPending_ = false;
+        lock.unlock();
+
+        if (!writeSamplesBlocking()) {
+            std::cerr << "[Audio] playback failed: " << lastError_ << std::endl;
+        }
+    }
+}
+
+bool AudioPlayer::writeSamplesBlocking()
+{
+    if (pcm_ == nullptr || samples_.empty() || frames_ == 0) {
+        lastError_ = "player not initialised";
+        return false;
+    }
+
+    int prepErr = snd_pcm_prepare(pcm_);
+    if (prepErr < 0) {
+        lastError_ = std::string("snd_pcm_prepare: ") + snd_strerror(prepErr);
+        return false;
+    }
+
+    const unsigned int frameBytes = channels_ * (bitsPerSample_ / 8);
+    snd_pcm_uframes_t remainingFrames = frames_;
+    const std::uint8_t* cursor = samples_.data();
+
+    while (remainingFrames > 0) {
+        snd_pcm_sframes_t written = snd_pcm_writei(pcm_, cursor, remainingFrames);
+        if (written == -EPIPE) {
+            snd_pcm_prepare(pcm_);
+            continue;
+        }
+        if (written == -EAGAIN) {
+            continue;
+        }
+        if (written < 0) {
+            int recoverErr = snd_pcm_recover(pcm_, static_cast<int>(written), 1);
+            if (recoverErr < 0) {
+                lastError_ = std::string("snd_pcm_recover: ") + snd_strerror(recoverErr);
+                return false;
+            }
+            continue;
+        }
+        cursor += static_cast<std::size_t>(written) * frameBytes;
+        remainingFrames -= static_cast<snd_pcm_uframes_t>(written);
+    }
+
+    snd_pcm_drain(pcm_);
+    return true;
+}

--- a/SonicSole_Audio.h
+++ b/SonicSole_Audio.h
@@ -1,0 +1,63 @@
+#ifndef SONICSOLE_AUDIO_H
+#define SONICSOLE_AUDIO_H
+
+#include <alsa/asoundlib.h>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+// Low-latency WAV player that keeps an ALSA PCM handle open and pre-loads
+// PCM samples into memory. play() returns immediately — a background
+// worker thread writes the samples to the device.
+//
+// Designed for the reaction-game use case where we need the gap between
+// "hit play" and "user hears the tone" to be short and predictable.
+class AudioPlayer {
+public:
+    AudioPlayer();
+    ~AudioPlayer();
+
+    AudioPlayer(const AudioPlayer&) = delete;
+    AudioPlayer& operator=(const AudioPlayer&) = delete;
+
+    // Loads `wavPath` into memory and opens the ALSA PCM device.
+    // `alsaDevice` is the ALSA device name (e.g. "default" or "plughw:0,0").
+    bool loadAndOpen(const std::string& wavPath, const std::string& alsaDevice);
+
+    // Closes the ALSA device and stops the worker thread.
+    void close();
+
+    bool isOpen() const { return pcm_ != nullptr; }
+
+    // Returns a timestamp (microseconds) captured immediately before
+    // signalling the worker thread, and kicks off playback asynchronously.
+    std::uint64_t play();
+
+    const std::string& lastError() const { return lastError_; }
+
+private:
+    void workerLoop();
+    bool writeSamplesBlocking();
+
+    snd_pcm_t* pcm_ = nullptr;
+    std::vector<std::uint8_t> samples_;
+    unsigned int channels_ = 0;
+    unsigned int sampleRate_ = 0;
+    unsigned int bitsPerSample_ = 0;
+    snd_pcm_format_t format_ = SND_PCM_FORMAT_UNKNOWN;
+    snd_pcm_uframes_t frames_ = 0;
+
+    std::thread worker_;
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::atomic<bool> stopping_{false};
+    bool playPending_ = false;
+
+    std::string lastError_;
+};
+
+#endif // SONICSOLE_AUDIO_H

--- a/SonicSole_RPi.cpp
+++ b/SonicSole_RPi.cpp
@@ -1,10 +1,12 @@
 #include "SonicSole.h"
 #include "SonicSole_Activity.h"
+#include "SonicSole_Audio.h"
 
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <string>
 #include <sys/time.h>
 #include <vector>
 
@@ -12,6 +14,8 @@ namespace {
 
 constexpr int kDefaultActivityPort = 21010;
 const char* const kActivityPortEnv = "SONICSOLE_ACTIVITY_PORT";
+const char* const kBeepPathEnv = "SONICSOLE_BEEP_WAV";
+const char* const kAlsaDeviceEnv = "SONICSOLE_ALSA_DEVICE";
 
 int resolveActivityPort()
 {
@@ -27,6 +31,15 @@ int resolveActivityPort()
         return kDefaultActivityPort;
     }
     return static_cast<int>(parsed);
+}
+
+std::string envOrDefault(const char* name, const std::string& fallback)
+{
+    const char* raw = std::getenv(name);
+    if (raw == nullptr || *raw == '\0') {
+        return fallback;
+    }
+    return std::string(raw);
 }
 
 void sendCurrentSensorPacket(SonicSole& sole)
@@ -53,11 +66,18 @@ int main(int /*argc*/, char* /*argv*/[])
     SonicSole sole;
     std::cout << "SonicSole Class Initialized" << std::endl;
 
+    AudioPlayer beepPlayer;
+    const std::string beepPath = envOrDefault(kBeepPathEnv, "beep.wav");
+    const std::string alsaDevice = envOrDefault(kAlsaDeviceEnv, "default");
+    if (!beepPlayer.loadAndOpen(beepPath, alsaDevice)) {
+        std::cerr << "Reaction audio disabled; continuing with a silent reaction cue."
+                  << std::endl;
+    }
+
     ActivityManager activityManager;
     activityManager.registerActivity(std::make_unique<BalanceActivity>());
-    // Add more activities here (jump, reaction, precision) by registering
-    // additional subclasses of ActivityBase. The command/response protocol
-    // and client wiring in the webapp are shared across activities.
+    activityManager.registerActivity(std::make_unique<ReactionActivity>(&beepPlayer));
+    // Add jump and precision the same way: subclass ActivityBase and register.
     if (!activityManager.start(resolveActivityPort())) {
         std::cerr << "Activity control listener disabled; sensor streaming only."
                   << std::endl;

--- a/web_page/app.py
+++ b/web_page/app.py
@@ -11,7 +11,6 @@ import random
 import struct
 import subprocess
 import sys
-import pygame
 import numpy as np
 import logging
 from threading import Thread 
@@ -1071,10 +1070,8 @@ threshold_fore = 350
 threshold_heel = 350
 dt = 0.009 #approx time (s) between samples from udp 
 
-pygame.init()
-pygame.mixer.init()
-CountSound = pygame.mixer.Sound("countdown.wav")
-CountSound.set_volume(0.1) 
+# Audio cues are produced on the RPi (see SonicSole_Audio / ReactionActivity
+# in the C++ source). The webapp is headless w.r.t. sound.
 
 
 def create_balance_session():
@@ -1160,6 +1157,7 @@ def reset_jump_state(cancel_session=False):
 
 def reset_reaction_state(cancel_session=False):
     global reaction_data, reaction_time
+    was_active = bool(reaction_data) and reaction_data.get("status") == "timing"
     if cancel_session:
         cancel_activity_session("reaction")
     reaction_data = {
@@ -1167,6 +1165,14 @@ def reset_reaction_state(cancel_session=False):
         "reaction_time": 0.0
     }
     reaction_time = "0"
+    if cancel_session and was_active:
+        device_ip = resolve_activity_device_ip()
+        if device_ip:
+            threading.Thread(
+                target=_send_activity_command_fire_and_forget,
+                args=(device_ip, "CANCEL reaction"),
+                daemon=True,
+            ).start()
 
 
 def reset_precision_trainer_state(cancel_session=False):
@@ -1457,18 +1463,6 @@ def stop_piano_activity():
     distance_from_origin = 0.0
     print("[Piano] Activity stopped")
 '''
-# sound
-@app.route("/play", methods=["GET", "POST"])
-def play():
-    # play sound using py
-    try:
-        CountSound.play()
-    except Exception as e:
-        print("Error playing sound:", e)
-        return jsonify({"error": str(e)}), 500
-    return send_file("countdown.wav") #to also play on laptop
-
-
 @app.after_request
 def add_no_cache_headers(response):
     if response.mimetype in ("text/html", "text/css", "application/javascript"):
@@ -1977,7 +1971,7 @@ def balancing():
 
 @app.route('/button_click', methods=['POST'])
 def button_click():
-    global recording_time, totalTime, CountSound
+    global recording_time, totalTime
     _, error_response = require_selected_group()
     if error_response is not None:
         return error_response
@@ -1992,7 +1986,7 @@ def button_click():
     session_id = create_balance_session()
     start_combined_data_thread()
     set_balance_status("countdown")
-    CountSound.play()
+    # Visual countdown runs in the browser; audio cues are emitted by the RPi.
     time.sleep(3.12)
     if session_id != get_balance_session_id():
         set_balance_status("idle")
@@ -2014,49 +2008,56 @@ def start_reaction():
     _, error_response = require_selected_group()
     if error_response is not None:
         return error_response
+    device_ip = resolve_activity_device_ip()
+    if not device_ip:
+        return jsonify({
+            "status": "error",
+            "message": "No SonicSole device is linked to the selected group yet.",
+        }), 400
+
     session_id = create_activity_session("reaction")
     reset_reaction_state(cancel_session=False)
-    received_fore_data = "0"
-    received_heel_data = "0"
     start_combined_data_thread()
-    reaction_data = {
-        "status": "waiting",
-        "reaction_time": 0.0
-    }
-    delay = random.uniform(3, 6.0)
-    print(f"[Reaction] Waiting for {delay:.2f}s")
-    start_time = time.time()
-    while time.time() - start_time < delay:
-        if not is_activity_session_active("reaction", session_id):
-            return jsonify({"status": "cancelled"})
-        if int(received_heel_data) > threshold_heel or int(received_fore_data) > threshold_fore:
-            print("[Reaction] Too early")
-            reaction_data["status"] = "invalid"
-            stop_combined_data_thread()
-            return jsonify({"status": "invalid"})
-        time.sleep(0.005)
-    beep = pygame.mixer.Sound("beep.wav")
-    beep.set_volume(1.0)
-    beep.play()
-    print("[Reaction] Beep")
-    reaction_data["status"] = "timing"
-    reaction_start = time.time()
-    while True:
-        if not is_activity_session_active("reaction", session_id):
-            return jsonify({"status": "cancelled"})
-        if int(received_heel_data) > threshold_heel or int(received_fore_data) > threshold_fore:
-            reaction_end = time.time()
-            reaction_time = round(reaction_end - reaction_start, 4)
-            reaction_data["reaction_time"] = reaction_time
-            reaction_data["status"] = "success"
-            print(f"[Reaction] Success! Reaction time: {reaction_time}")
-          
-            # with open("SonicSoleReaction.txt", "a") as f:
-            #     f.write(f"{submitted_name2},{reaction_time}\n")
-            
-            stop_combined_data_thread()
-            return jsonify({"status": "success"})
-        time.sleep(0.001)
+    reaction_data = {"status": "timing", "reaction_time": 0.0}
+
+    threading.Thread(
+        target=_run_reaction_on_rpi,
+        args=(session_id, device_ip),
+        daemon=True,
+    ).start()
+    return jsonify({"status": "timing"})
+
+
+def _run_reaction_on_rpi(session_id, device_ip):
+    global reaction_data, reaction_time
+    try:
+        reply = send_rpi_activity_command(device_ip, "START reaction")
+    except ActivityCommandError as command_error:
+        print(f"[reaction] command failed: {command_error.reason}")
+        if session_id == get_activity_session_id("reaction"):
+            reaction_data = {"status": "error", "reaction_time": 0.0, "reason": command_error.reason}
+        return
+
+    if session_id != get_activity_session_id("reaction"):
+        print("[reaction] session changed while waiting for RPi; discarding reply")
+        return
+
+    if reply["success"] and reply.get("score") is not None:
+        score_value = round(float(reply["score"]), 4)
+        reaction_time = score_value
+        reaction_data = {"status": "success", "reaction_time": score_value}
+        print(f"[reaction] score={score_value}s from RPi")
+        return
+
+    reason = reply.get("reason") or "error"
+    if reason == "too_early":
+        reaction_data = {"status": "invalid", "reaction_time": 0.0}
+        print("[reaction] RPi reported: too_early")
+        return
+
+    reaction_data = {"status": "error", "reaction_time": 0.0, "reason": reason}
+    print(f"[reaction] RPi reported failure: {reason}")
+
 
 @app.route('/reaction_status')
 def reaction_status():


### PR DESCRIPTION
## Summary
- The webapp no longer owns any audio. All cues play on the RPi next to the insole so the participant actually hears them.
- `pygame` is removed from the Mac server entirely, which also unblocks the case where SDL picked `alsa` as its audio driver and `pygame.mixer.init()` crashed the Flask app at import time.
- Adds a low-latency ALSA player + `ReactionActivity` on the RPi using the existing activity framework.

## Runtime flow
```
phone → POST /start_reaction (Mac webapp)
Mac  → UDP "START reaction" (RPi port 21010)
RPi  → [random 3-6s] → AudioPlayer.play() → audio-board speaker
user → foot lands
RPi  → stopwatch stops → "OK reaction 0.2341" (UDP back to Mac)
Mac  → reaction_data = {status: success, reaction_time: 0.2341}
phone polls /reaction_status, sees success, shows result + form
```

## What changed

**RPi — new ALSA audio player** ([SonicSole_Audio.h](SonicSole_Audio.h), [SonicSole_Audio.cpp](SonicSole_Audio.cpp))
- Parses `beep.wav` once at startup and keeps the ALSA PCM handle open with a small period/buffer (512 / 2048 frames). A worker thread does the blocking `snd_pcm_writei`, so `play()` just captures a micro-timestamp and signals the worker — worst-case audible lag ~12 ms at 44.1 kHz.
- Device override: `SONICSOLE_ALSA_DEVICE` (default `"default"`); file override: `SONICSOLE_BEEP_WAV`.

**RPi — ReactionActivity** ([SonicSole_Activity.h](SonicSole_Activity.h), [SonicSole_Activity.cpp](SonicSole_Activity.cpp))
- Phase 1 waits a random 3–6 s (env: `SONICSOLE_REACTION_MIN_DELAY` / `…_MAX_DELAY`). An early press → `ERR reaction too_early`.
- Phase 2 calls `AudioPlayer::play()` to fire the beep locally, captures the beep timestamp, then returns `OK reaction <seconds>` when pressure crosses `SONICSOLE_REACTION_THRESHOLD` (default 350). `SONICSOLE_REACTION_MAX_REACT` caps no-press runs.

**RPi — wiring** ([SonicSole_RPi.cpp](SonicSole_RPi.cpp), [Makefile](Makefile))
- Creates and loads the player, registers `BalanceActivity` and `ReactionActivity`.
- Makefile picks up `SonicSole_Audio.cpp` and links `-lasound`.

**Webapp — pygame removed** ([web_page/app.py](web_page/app.py))
- Dropped `import pygame`, the mixer init block, `CountSound` / `ReactionBeep`, the `/play` route, the `CountSound.play()` call inside `/button_click`, and the `beep = pygame.mixer.Sound(…)` inside `/start_reaction`. The visual JS countdown in `balance.html` is unchanged — no audio needed on the Mac.
- `/start_reaction` is a thin wrapper: spawns a worker thread that sends `START reaction` to the RPi and writes the returned score into `reaction_data`. Returns `{status: timing}` immediately so the browser shows "Wait for the sound" right away instead of hanging for 3–10 s.
- `reset_reaction_state(cancel_session=True)` fires a best-effort `CANCEL reaction` UDP to the RPi, mirroring the balance teardown.

## Test plan
- [ ] On the RPi: `sudo apt install libasound2-dev` (one-time), then `./compile_C_RPi_Andy.sh` rebuilds cleanly. Startup log shows `[Audio] Ready: beep.wav …` and `[Activity] Registered activity 'reaction'`.
- [ ] If the default ALSA device isn't the audio board: `aplay -L`, then re-run with `SONICSOLE_ALSA_DEVICE="plughw:CARD=…,DEV=0"`.
- [ ] Mac webapp starts without the prior SDL/alsa crash; `/phone/group1/reaction` renders unchanged.
- [ ] Click Start on the phone → 3–6 s later the RPi plays the beep → press foot → phone shows reaction time and the Submit form.
- [ ] Press too early → phone shows "Invalid attempt. You moved too early." (RPi returned `ERR reaction too_early`).
- [ ] Stop mid-run: `reset_reaction_state` fires `CANCEL reaction`; a fresh Start supersedes any stuck run on the RPi side.