### PR TITLE
Swap ALSA-direct beep for aplay fork/exec on EOL Buster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX := g++
 CPPFLAGS := -MMD -MP
 CXXFLAGS := -std=c++17
-LDLIBS := -lwiringPi -lpthread -lasound
+LDLIBS := -lwiringPi -lpthread
 
 TARGET := SonicSole_RPi
 BUILD_DIR := build/sonicsole_rpi

--- a/SonicSole_Audio.cpp
+++ b/SonicSole_Audio.cpp
@@ -1,111 +1,41 @@
 #include "SonicSole_Audio.h"
 #include "SonicSole.h"
 
+#include <cerrno>
+#include <csignal>
 #include <cstring>
+#include <fcntl.h>
 #include <fstream>
 #include <iostream>
-#include <sstream>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 namespace {
 
-// Parses a PCM .wav file into `outSamples`. Fills channel / sample rate /
-// bits-per-sample metadata. Only 8- or 16-bit integer PCM is supported.
-bool loadPcmWav(
-    const std::string& path,
-    std::vector<std::uint8_t>& outSamples,
-    unsigned int& outChannels,
-    unsigned int& outSampleRate,
-    unsigned int& outBitsPerSample,
-    std::string& outError)
+bool fileExists(const std::string& path)
 {
-    std::ifstream file(path, std::ios::binary);
-    if (!file) {
-        outError = "cannot open " + path;
-        return false;
-    }
+    std::ifstream probe(path);
+    return probe.good();
+}
 
-    char riff[4] = {};
-    char wave[4] = {};
-    std::uint32_t chunkSize = 0;
-    file.read(riff, 4);
-    file.read(reinterpret_cast<char*>(&chunkSize), 4);
-    file.read(wave, 4);
-    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
-        outError = "not a RIFF/WAVE file";
-        return false;
-    }
-
-    bool fmtFound = false;
-    bool dataFound = false;
-    std::uint16_t audioFormat = 0;
-    std::uint16_t channels = 0;
-    std::uint32_t sampleRate = 0;
-    std::uint16_t bitsPerSample = 0;
-
-    while (file && !dataFound) {
-        char chunkId[4] = {};
-        std::uint32_t chunkBytes = 0;
-        if (!file.read(chunkId, 4)) {
-            break;
-        }
-        if (!file.read(reinterpret_cast<char*>(&chunkBytes), 4)) {
-            break;
-        }
-
-        if (std::memcmp(chunkId, "fmt ", 4) == 0) {
-            std::uint32_t fmtRead = 0;
-            std::uint16_t blockAlign = 0;
-            std::uint32_t byteRate = 0;
-            file.read(reinterpret_cast<char*>(&audioFormat), 2);
-            file.read(reinterpret_cast<char*>(&channels), 2);
-            file.read(reinterpret_cast<char*>(&sampleRate), 4);
-            file.read(reinterpret_cast<char*>(&byteRate), 4);
-            file.read(reinterpret_cast<char*>(&blockAlign), 2);
-            file.read(reinterpret_cast<char*>(&bitsPerSample), 2);
-            fmtRead = 16;
-            if (chunkBytes > fmtRead) {
-                file.seekg(chunkBytes - fmtRead, std::ios::cur);
-            }
-            fmtFound = true;
-        } else if (std::memcmp(chunkId, "data", 4) == 0) {
-            outSamples.resize(chunkBytes);
-            file.read(reinterpret_cast<char*>(outSamples.data()), chunkBytes);
-            dataFound = true;
-        } else {
-            file.seekg(chunkBytes, std::ios::cur);
-        }
-    }
-
-    if (!fmtFound) {
-        outError = "missing fmt chunk";
-        return false;
-    }
-    if (!dataFound) {
-        outError = "missing data chunk";
-        return false;
-    }
-    if (audioFormat != 1) {
-        std::ostringstream message;
-        message << "unsupported audioFormat=" << audioFormat << " (only PCM is handled)";
-        outError = message.str();
-        return false;
-    }
-    if (bitsPerSample != 16 && bitsPerSample != 8) {
-        std::ostringstream message;
-        message << "unsupported bitsPerSample=" << bitsPerSample;
-        outError = message.str();
-        return false;
-    }
-
-    outChannels = channels;
-    outSampleRate = sampleRate;
-    outBitsPerSample = bitsPerSample;
-    return true;
+void ignoreChildExits()
+{
+    // Reap children automatically so fire-and-forget `aplay` calls don't
+    // leave zombie processes hanging around between rounds.
+    struct sigaction sa;
+    std::memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = SIG_IGN;
+    sa.sa_flags = SA_NOCLDWAIT;
+    sigaction(SIGCHLD, &sa, nullptr);
 }
 
 } // namespace
 
-AudioPlayer::AudioPlayer() = default;
+AudioPlayer::AudioPlayer()
+{
+    ignoreChildExits();
+}
 
 AudioPlayer::~AudioPlayer()
 {
@@ -114,154 +44,61 @@ AudioPlayer::~AudioPlayer()
 
 bool AudioPlayer::loadAndOpen(const std::string& wavPath, const std::string& alsaDevice)
 {
-    close();
-
-    std::string loadError;
-    if (!loadPcmWav(wavPath, samples_, channels_, sampleRate_, bitsPerSample_, loadError)) {
-        lastError_ = "loadPcmWav: " + loadError;
+    if (!fileExists(wavPath)) {
+        lastError_ = "cannot open " + wavPath;
         std::cerr << "[Audio] " << lastError_ << std::endl;
+        open_ = false;
         return false;
     }
 
-    format_ = (bitsPerSample_ == 16) ? SND_PCM_FORMAT_S16_LE : SND_PCM_FORMAT_U8;
-    const unsigned int frameBytes = channels_ * (bitsPerSample_ / 8);
-    if (frameBytes == 0) {
-        lastError_ = "invalid frame size computed from WAV header";
-        std::cerr << "[Audio] " << lastError_ << std::endl;
-        return false;
-    }
-    frames_ = samples_.size() / frameBytes;
+    wavPath_ = wavPath;
+    alsaDevice_ = alsaDevice.empty() ? "default" : alsaDevice;
+    open_ = true;
 
-    int openErr = snd_pcm_open(&pcm_, alsaDevice.c_str(), SND_PCM_STREAM_PLAYBACK, 0);
-    if (openErr < 0) {
-        lastError_ = std::string("snd_pcm_open(") + alsaDevice + "): " + snd_strerror(openErr);
-        std::cerr << "[Audio] " << lastError_ << std::endl;
-        pcm_ = nullptr;
-        return false;
-    }
-
-    snd_pcm_hw_params_t* params = nullptr;
-    snd_pcm_hw_params_alloca(&params);
-    snd_pcm_hw_params_any(pcm_, params);
-    snd_pcm_hw_params_set_access(pcm_, params, SND_PCM_ACCESS_RW_INTERLEAVED);
-    snd_pcm_hw_params_set_format(pcm_, params, format_);
-    snd_pcm_hw_params_set_channels(pcm_, params, channels_);
-    unsigned int requestedRate = sampleRate_;
-    snd_pcm_hw_params_set_rate_near(pcm_, params, &requestedRate, nullptr);
-    sampleRate_ = requestedRate;
-
-    // Small buffer keeps "write returns" close to "sound is audible".
-    snd_pcm_uframes_t bufferFrames = 2048;
-    snd_pcm_hw_params_set_buffer_size_near(pcm_, params, &bufferFrames);
-    snd_pcm_uframes_t periodFrames = 512;
-    snd_pcm_hw_params_set_period_size_near(pcm_, params, &periodFrames, nullptr);
-
-    int paramsErr = snd_pcm_hw_params(pcm_, params);
-    if (paramsErr < 0) {
-        lastError_ = std::string("snd_pcm_hw_params: ") + snd_strerror(paramsErr);
-        std::cerr << "[Audio] " << lastError_ << std::endl;
-        snd_pcm_close(pcm_);
-        pcm_ = nullptr;
-        return false;
-    }
-
-    std::cout << "[Audio] Ready: " << wavPath
-              << " (" << sampleRate_ << " Hz, "
-              << channels_ << " ch, "
-              << bitsPerSample_ << "-bit, "
-              << frames_ << " frames) on " << alsaDevice
-              << std::endl;
-
-    stopping_ = false;
-    playPending_ = false;
-    worker_ = std::thread(&AudioPlayer::workerLoop, this);
+    std::cout << "[Audio] aplay backend ready: " << wavPath_
+              << " on device " << alsaDevice_ << std::endl;
     return true;
 }
 
 void AudioPlayer::close()
 {
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        stopping_ = true;
-        playPending_ = false;
-    }
-    cv_.notify_all();
-    if (worker_.joinable()) {
-        worker_.join();
-    }
-    if (pcm_ != nullptr) {
-        snd_pcm_close(pcm_);
-        pcm_ = nullptr;
-    }
-    samples_.clear();
+    open_ = false;
 }
 
 std::uint64_t AudioPlayer::play()
 {
-    const std::uint64_t ts = getMicrosTimeStamp();
-    {
-        std::lock_guard<std::mutex> lock(mutex_);
-        playPending_ = true;
-    }
-    cv_.notify_one();
-    return ts;
-}
-
-void AudioPlayer::workerLoop()
-{
-    while (true) {
-        std::unique_lock<std::mutex> lock(mutex_);
-        cv_.wait(lock, [this] { return playPending_ || stopping_.load(); });
-        if (stopping_.load()) {
-            return;
-        }
-        playPending_ = false;
-        lock.unlock();
-
-        if (!writeSamplesBlocking()) {
-            std::cerr << "[Audio] playback failed: " << lastError_ << std::endl;
-        }
-    }
-}
-
-bool AudioPlayer::writeSamplesBlocking()
-{
-    if (pcm_ == nullptr || samples_.empty() || frames_ == 0) {
-        lastError_ = "player not initialised";
-        return false;
+    const std::uint64_t dispatchedAt = getMicrosTimeStamp();
+    if (!open_) {
+        return dispatchedAt;
     }
 
-    int prepErr = snd_pcm_prepare(pcm_);
-    if (prepErr < 0) {
-        lastError_ = std::string("snd_pcm_prepare: ") + snd_strerror(prepErr);
-        return false;
+    const pid_t pid = fork();
+    if (pid < 0) {
+        lastError_ = std::string("fork failed: ") + std::strerror(errno);
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        return dispatchedAt;
     }
 
-    const unsigned int frameBytes = channels_ * (bitsPerSample_ / 8);
-    snd_pcm_uframes_t remainingFrames = frames_;
-    const std::uint8_t* cursor = samples_.data();
-
-    while (remainingFrames > 0) {
-        snd_pcm_sframes_t written = snd_pcm_writei(pcm_, cursor, remainingFrames);
-        if (written == -EPIPE) {
-            snd_pcm_prepare(pcm_);
-            continue;
+    if (pid == 0) {
+        // Child: silence aplay's stdout/stderr and exec it.
+        const int devnull = ::open("/dev/null", O_WRONLY);
+        if (devnull >= 0) {
+            dup2(devnull, STDOUT_FILENO);
+            dup2(devnull, STDERR_FILENO);
+            ::close(devnull);
         }
-        if (written == -EAGAIN) {
-            continue;
-        }
-        if (written < 0) {
-            int recoverErr = snd_pcm_recover(pcm_, static_cast<int>(written), 1);
-            if (recoverErr < 0) {
-                lastError_ = std::string("snd_pcm_recover: ") + snd_strerror(recoverErr);
-                return false;
-            }
-            continue;
-        }
-        cursor += static_cast<std::size_t>(written) * frameBytes;
-        remainingFrames -= static_cast<snd_pcm_uframes_t>(written);
+        execlp(
+            "aplay",
+            "aplay",
+            "-q",
+            "-D", alsaDevice_.c_str(),
+            wavPath_.c_str(),
+            static_cast<char*>(nullptr)
+        );
+        _exit(127);
     }
 
-    snd_pcm_drain(pcm_);
-    return true;
+    // Parent: don't wait. SIGCHLD is ignored with SA_NOCLDWAIT so the child
+    // won't become a zombie.
+    return dispatchedAt;
 }

--- a/SonicSole_Audio.h
+++ b/SonicSole_Audio.h
@@ -1,21 +1,17 @@
 #ifndef SONICSOLE_AUDIO_H
 #define SONICSOLE_AUDIO_H
 
-#include <alsa/asoundlib.h>
-#include <atomic>
-#include <condition_variable>
 #include <cstdint>
-#include <mutex>
 #include <string>
-#include <thread>
-#include <vector>
 
-// Low-latency WAV player that keeps an ALSA PCM handle open and pre-loads
-// PCM samples into memory. play() returns immediately — a background
-// worker thread writes the samples to the device.
+// Lightweight WAV player built on `aplay`.
 //
-// Designed for the reaction-game use case where we need the gap between
-// "hit play" and "user hears the tone" to be short and predictable.
+// We fork + execvp `aplay` so we don't depend on libasound dev headers
+// being installable on the target (Raspbian Buster's repositories are
+// EOL, and matching `libasound2-dev` is hard to get onto those images).
+// The audible lag is dominated by aplay's startup (~50-150 ms on a
+// Pi 3/4). For the reaction-game use case this is a constant per-run
+// bias rather than a precision issue.
 class AudioPlayer {
 public:
     AudioPlayer();
@@ -24,39 +20,24 @@ public:
     AudioPlayer(const AudioPlayer&) = delete;
     AudioPlayer& operator=(const AudioPlayer&) = delete;
 
-    // Loads `wavPath` into memory and opens the ALSA PCM device.
-    // `alsaDevice` is the ALSA device name (e.g. "default" or "plughw:0,0").
+    // Validates that `wavPath` exists and remembers the paired ALSA
+    // device (passed through as `aplay -D <device>`).
     bool loadAndOpen(const std::string& wavPath, const std::string& alsaDevice);
 
-    // Closes the ALSA device and stops the worker thread.
     void close();
+    bool isOpen() const { return open_; }
 
-    bool isOpen() const { return pcm_ != nullptr; }
-
-    // Returns a timestamp (microseconds) captured immediately before
-    // signalling the worker thread, and kicks off playback asynchronously.
+    // Forks aplay asynchronously. Returns the micro-timestamp captured
+    // just before forking, so the caller can anchor a stopwatch against
+    // the moment we dispatched the beep.
     std::uint64_t play();
 
     const std::string& lastError() const { return lastError_; }
 
 private:
-    void workerLoop();
-    bool writeSamplesBlocking();
-
-    snd_pcm_t* pcm_ = nullptr;
-    std::vector<std::uint8_t> samples_;
-    unsigned int channels_ = 0;
-    unsigned int sampleRate_ = 0;
-    unsigned int bitsPerSample_ = 0;
-    snd_pcm_format_t format_ = SND_PCM_FORMAT_UNKNOWN;
-    snd_pcm_uframes_t frames_ = 0;
-
-    std::thread worker_;
-    std::mutex mutex_;
-    std::condition_variable cv_;
-    std::atomic<bool> stopping_{false};
-    bool playPending_ = false;
-
+    std::string wavPath_;
+    std::string alsaDevice_ = "default";
+    bool open_ = false;
     std::string lastError_;
 };
 


### PR DESCRIPTION
## Summary
- Raspbian Buster's apt repositories are EOL, so `libasound2-dev` can't be installed against the stock `libasound2` that ships on the image (dependency version mismatch). That broke `#include <alsa/asoundlib.h>` at compile time.
- Switch the RPi beep player to fork+execvp `aplay`, which is already present on every Raspbian install and needs no dev headers.

## Tradeoff
- `aplay` startup adds ~50–150 ms per shot on a Pi 3/4 (process exec + WAV parse + PCM open + initial buffer fill).
- For the reaction game this is a **constant per-run bias**, not a precision issue — every participant gets the same offset, so score *differences* are preserved.
- When the Pi moves to bookworm (or `libasound2-dev` becomes installable), restoring the ALSA-direct player is a local-only change; the activity framework contract is unchanged.

## Changes
- [SonicSole_Audio.h](SonicSole_Audio.h) / [SonicSole_Audio.cpp](SonicSole_Audio.cpp): rewrite as a thin `fork` + `execvp("aplay", "-q", "-D", <device>, <path>, …)`. SIGCHLD is masked with `SA_NOCLDWAIT` so fire-and-forget plays don't leave zombies. `play()` still returns the micro-timestamp captured just before the fork, which is what `ReactionActivity` uses to anchor its stopwatch.
- [Makefile](Makefile): drop `-lasound`; only `-lwiringPi -lpthread` now.

## Test plan
- [ ] On the RPi (Buster): `./compile_C_RPi_Andy.sh` compiles cleanly without installing any new packages.
- [ ] Startup log shows `[Audio] aplay backend ready: beep.wav on device default`.
- [ ] `/phone/group1/reaction` → Start → after the random delay the RPi speaker plays the beep → foot lands → score displayed.
- [ ] If `default` isn't the audio-board output: `aplay -L`, then `SONICSOLE_ALSA_DEVICE="plughw:CARD=…,DEV=0" ./run_RPi_combined.sh`.