### PR TITLE
Persistent aplay pipe for sub-10ms reaction beep

### DIFF
--- a/SonicSole_Audio.cpp
+++ b/SonicSole_Audio.cpp
@@ -7,27 +7,104 @@
 #include <fcntl.h>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
 
 namespace {
 
-bool fileExists(const std::string& path)
-{
-    std::ifstream probe(path);
-    return probe.good();
-}
-
 void ignoreChildExits()
 {
-    // Reap children automatically so fire-and-forget `aplay` calls don't
-    // leave zombie processes hanging around between rounds.
+    // SA_NOCLDWAIT lets the aplay child be auto-reaped on exit so we
+    // don't need a dedicated waiter. (We don't care about the status.)
     struct sigaction sa;
     std::memset(&sa, 0, sizeof(sa));
     sa.sa_handler = SIG_IGN;
     sa.sa_flags = SA_NOCLDWAIT;
     sigaction(SIGCHLD, &sa, nullptr);
+}
+
+bool loadPcmWav(
+    const std::string& path,
+    std::vector<std::uint8_t>& outSamples,
+    unsigned int& outChannels,
+    unsigned int& outSampleRate,
+    unsigned int& outBitsPerSample,
+    std::string& outError)
+{
+    std::ifstream file(path, std::ios::binary);
+    if (!file) {
+        outError = "cannot open " + path;
+        return false;
+    }
+
+    char riff[4] = {};
+    char wave[4] = {};
+    std::uint32_t riffSize = 0;
+    file.read(riff, 4);
+    file.read(reinterpret_cast<char*>(&riffSize), 4);
+    file.read(wave, 4);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(wave, "WAVE", 4) != 0) {
+        outError = "not a RIFF/WAVE file";
+        return false;
+    }
+
+    bool fmtFound = false;
+    bool dataFound = false;
+    std::uint16_t audioFormat = 0;
+    std::uint16_t channels = 0;
+    std::uint32_t sampleRate = 0;
+    std::uint16_t bitsPerSample = 0;
+
+    while (file && !dataFound) {
+        char chunkId[4] = {};
+        std::uint32_t chunkBytes = 0;
+        if (!file.read(chunkId, 4)) break;
+        if (!file.read(reinterpret_cast<char*>(&chunkBytes), 4)) break;
+
+        if (std::memcmp(chunkId, "fmt ", 4) == 0) {
+            std::uint16_t blockAlign = 0;
+            std::uint32_t byteRate = 0;
+            file.read(reinterpret_cast<char*>(&audioFormat), 2);
+            file.read(reinterpret_cast<char*>(&channels), 2);
+            file.read(reinterpret_cast<char*>(&sampleRate), 4);
+            file.read(reinterpret_cast<char*>(&byteRate), 4);
+            file.read(reinterpret_cast<char*>(&blockAlign), 2);
+            file.read(reinterpret_cast<char*>(&bitsPerSample), 2);
+            if (chunkBytes > 16) {
+                file.seekg(chunkBytes - 16, std::ios::cur);
+            }
+            fmtFound = true;
+        } else if (std::memcmp(chunkId, "data", 4) == 0) {
+            outSamples.resize(chunkBytes);
+            file.read(reinterpret_cast<char*>(outSamples.data()), chunkBytes);
+            dataFound = true;
+        } else {
+            file.seekg(chunkBytes, std::ios::cur);
+        }
+    }
+
+    if (!fmtFound) { outError = "missing fmt chunk"; return false; }
+    if (!dataFound) { outError = "missing data chunk"; return false; }
+    if (audioFormat != 1) {
+        std::ostringstream message;
+        message << "unsupported audioFormat=" << audioFormat << " (PCM only)";
+        outError = message.str();
+        return false;
+    }
+    if (bitsPerSample != 16 && bitsPerSample != 8) {
+        std::ostringstream message;
+        message << "unsupported bitsPerSample=" << bitsPerSample;
+        outError = message.str();
+        return false;
+    }
+
+    outChannels = channels;
+    outSampleRate = sampleRate;
+    outBitsPerSample = bitsPerSample;
+    return true;
 }
 
 } // namespace
@@ -42,63 +119,162 @@ AudioPlayer::~AudioPlayer()
     close();
 }
 
-bool AudioPlayer::loadAndOpen(const std::string& wavPath, const std::string& alsaDevice)
+bool AudioPlayer::parseWav(const std::string& path)
 {
-    if (!fileExists(wavPath)) {
-        lastError_ = "cannot open " + wavPath;
-        std::cerr << "[Audio] " << lastError_ << std::endl;
-        open_ = false;
+    std::string err;
+    if (!loadPcmWav(path, pcmData_, channels_, sampleRate_, bitsPerSample_, err)) {
+        lastError_ = "loadPcmWav: " + err;
         return false;
     }
-
-    wavPath_ = wavPath;
-    alsaDevice_ = alsaDevice.empty() ? "default" : alsaDevice;
-    open_ = true;
-
-    std::cout << "[Audio] aplay backend ready: " << wavPath_
-              << " on device " << alsaDevice_ << std::endl;
     return true;
 }
 
-void AudioPlayer::close()
+bool AudioPlayer::spawnAplay(const std::string& alsaDevice)
 {
-    open_ = false;
-}
-
-std::uint64_t AudioPlayer::play()
-{
-    const std::uint64_t dispatchedAt = getMicrosTimeStamp();
-    if (!open_) {
-        return dispatchedAt;
+    int pipeFds[2] = {-1, -1};
+    if (pipe(pipeFds) < 0) {
+        lastError_ = std::string("pipe: ") + std::strerror(errno);
+        return false;
     }
+
+    const std::string fmtStr = (bitsPerSample_ == 16) ? "S16_LE" : "U8";
+    const std::string chStr = std::to_string(channels_);
+    const std::string rateStr = std::to_string(sampleRate_);
+    const std::string device = alsaDevice.empty() ? std::string("default") : alsaDevice;
 
     const pid_t pid = fork();
     if (pid < 0) {
-        lastError_ = std::string("fork failed: ") + std::strerror(errno);
-        std::cerr << "[Audio] " << lastError_ << std::endl;
-        return dispatchedAt;
+        ::close(pipeFds[0]);
+        ::close(pipeFds[1]);
+        lastError_ = std::string("fork: ") + std::strerror(errno);
+        return false;
     }
 
     if (pid == 0) {
-        // Child: silence aplay's stdout/stderr and exec it.
+        // Child: aplay reads raw PCM from our pipe.
+        if (dup2(pipeFds[0], STDIN_FILENO) < 0) {
+            _exit(126);
+        }
+        ::close(pipeFds[0]);
+        ::close(pipeFds[1]);
+
         const int devnull = ::open("/dev/null", O_WRONLY);
         if (devnull >= 0) {
             dup2(devnull, STDOUT_FILENO);
             dup2(devnull, STDERR_FILENO);
             ::close(devnull);
         }
+
+        // Small buffer keeps aplay's own internal latency tight.
         execlp(
             "aplay",
             "aplay",
             "-q",
-            "-D", alsaDevice_.c_str(),
-            wavPath_.c_str(),
+            "-t", "raw",
+            "-c", chStr.c_str(),
+            "-r", rateStr.c_str(),
+            "-f", fmtStr.c_str(),
+            "-D", device.c_str(),
+            "--buffer-time=50000",
+            "--period-time=10000",
             static_cast<char*>(nullptr)
         );
         _exit(127);
     }
 
-    // Parent: don't wait. SIGCHLD is ignored with SA_NOCLDWAIT so the child
-    // won't become a zombie.
-    return dispatchedAt;
+    ::close(pipeFds[0]);
+    aplayStdin_ = pipeFds[1];
+    aplayPid_ = pid;
+    return true;
+}
+
+bool AudioPlayer::loadAndOpen(const std::string& wavPath, const std::string& alsaDevice)
+{
+    close();
+
+    if (!parseWav(wavPath)) {
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        return false;
+    }
+    if (!spawnAplay(alsaDevice)) {
+        std::cerr << "[Audio] " << lastError_ << std::endl;
+        return false;
+    }
+
+    std::cout << "[Audio] Persistent aplay ready: " << wavPath
+              << " (" << sampleRate_ << " Hz, " << channels_ << " ch, "
+              << bitsPerSample_ << "-bit, " << pcmData_.size() << " PCM bytes) on "
+              << (alsaDevice.empty() ? "default" : alsaDevice) << std::endl;
+
+    // Pre-warm: ~200 ms of silence so aplay opens the ALSA device and
+    // its startup click fires before the first reaction shot. Without
+    // this, the first play() landed a faint click before the beep.
+    const unsigned int frameBytes = channels_ * (bitsPerSample_ / 8);
+    if (frameBytes > 0) {
+        const std::size_t warmBytes =
+            (static_cast<std::size_t>(sampleRate_) * frameBytes) / 5;
+        std::vector<std::uint8_t> silence(warmBytes, 0);
+        blockingWrite(silence.data(), silence.size());
+    }
+    return true;
+}
+
+long AudioPlayer::blockingWrite(const std::uint8_t* data, std::size_t len)
+{
+    if (aplayStdin_ < 0) return -1;
+    std::size_t written = 0;
+    while (written < len) {
+        const ssize_t n = ::write(aplayStdin_, data + written, len - written);
+        if (n < 0) {
+            if (errno == EINTR || errno == EAGAIN) continue;
+            lastError_ = std::string("write: ") + std::strerror(errno);
+            return -1;
+        }
+        written += static_cast<std::size_t>(n);
+    }
+    return static_cast<long>(written);
+}
+
+std::uint64_t AudioPlayer::play()
+{
+    const std::uint64_t ts = getMicrosTimeStamp();
+    if (aplayStdin_ < 0 || pcmData_.empty()) {
+        return ts;
+    }
+
+    // Copy fd + PCM into the writer thread so close() is always safe.
+    const int fdCopy = aplayStdin_;
+    std::vector<std::uint8_t> dataCopy = pcmData_;
+    std::thread(
+        [fdCopy, dataCopy = std::move(dataCopy)]() {
+            std::size_t written = 0;
+            while (written < dataCopy.size()) {
+                const ssize_t n = ::write(
+                    fdCopy,
+                    dataCopy.data() + written,
+                    dataCopy.size() - written);
+                if (n < 0) {
+                    if (errno == EINTR || errno == EAGAIN) continue;
+                    std::cerr << "[Audio] write failed: "
+                              << std::strerror(errno) << std::endl;
+                    return;
+                }
+                written += static_cast<std::size_t>(n);
+            }
+        }
+    ).detach();
+
+    return ts;
+}
+
+void AudioPlayer::close()
+{
+    if (aplayStdin_ >= 0) {
+        ::close(aplayStdin_);
+        aplayStdin_ = -1;
+    }
+    // Child is auto-reaped because of SA_NOCLDWAIT; it will exit when
+    // it hits EOF on stdin (stdin closed above).
+    aplayPid_ = -1;
+    pcmData_.clear();
 }

--- a/SonicSole_Audio.h
+++ b/SonicSole_Audio.h
@@ -3,15 +3,21 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
-// Lightweight WAV player built on `aplay`.
+// Low-latency WAV player backed by a long-running `aplay` child.
 //
-// We fork + execvp `aplay` so we don't depend on libasound dev headers
-// being installable on the target (Raspbian Buster's repositories are
-// EOL, and matching `libasound2-dev` is hard to get onto those images).
-// The audible lag is dominated by aplay's startup (~50-150 ms on a
-// Pi 3/4). For the reaction-game use case this is a constant per-run
-// bias rather than a precision issue.
+// Approach:
+//   1. Parse the WAV file once at startup into raw PCM + format metadata.
+//   2. Fork `aplay -q -t raw ...` reading from a pipe we keep open.
+//   3. Pre-warm the pipe with a short silence so the ALSA device opens
+//      (and its click/pop fires) before the participant is listening.
+//   4. play() just writes the cached PCM bytes into the pipe — no
+//      fork/exec, no WAV parse, no ALSA open on the hot path.
+//
+// Compared with fork+exec'ing aplay on every shot this cuts audible
+// latency from ~50-150 ms down to a few ms, and removes the startup
+// click that was landing right before the real beep.
 class AudioPlayer {
 public:
     AudioPlayer();
@@ -20,24 +26,38 @@ public:
     AudioPlayer(const AudioPlayer&) = delete;
     AudioPlayer& operator=(const AudioPlayer&) = delete;
 
-    // Validates that `wavPath` exists and remembers the paired ALSA
-    // device (passed through as `aplay -D <device>`).
+    // Loads `wavPath` into memory and spawns the persistent aplay
+    // worker. After this returns true, the ALSA device is already open
+    // and a short silence has been pushed through it.
     bool loadAndOpen(const std::string& wavPath, const std::string& alsaDevice);
 
+    // Shuts down the aplay worker; the child drains whatever is in
+    // flight and then exits when it sees EOF on stdin.
     void close();
-    bool isOpen() const { return open_; }
 
-    // Forks aplay asynchronously. Returns the micro-timestamp captured
-    // just before forking, so the caller can anchor a stopwatch against
-    // the moment we dispatched the beep.
+    bool isOpen() const { return aplayStdin_ >= 0; }
+
+    // Non-blocking. Returns the micro-timestamp captured just before we
+    // hand off the PCM bytes to the background writer thread.
     std::uint64_t play();
 
     const std::string& lastError() const { return lastError_; }
 
 private:
-    std::string wavPath_;
-    std::string alsaDevice_ = "default";
-    bool open_ = false;
+    bool parseWav(const std::string& path);
+    bool spawnAplay(const std::string& alsaDevice);
+    // Writes `len` bytes into the aplay stdin pipe. Returns number of
+    // bytes actually written; -1 on fatal error.
+    long blockingWrite(const std::uint8_t* data, std::size_t len);
+
+    std::vector<std::uint8_t> pcmData_;
+    unsigned int channels_ = 2;
+    unsigned int sampleRate_ = 44100;
+    unsigned int bitsPerSample_ = 16;
+
+    int aplayStdin_ = -1;
+    int aplayPid_ = -1;
+
     std::string lastError_;
 };
 


### PR DESCRIPTION
## Summary
- Drop the per-shot `fork+exec aplay beep.wav` and replace it with a single long-running `aplay` child reading raw PCM from a pipe we keep open. `play()` just writes the cached PCM bytes into that pipe.
- Fixes the two things you hit on the Pi:
  - **Large delay** — every shot was paying for a process start + WAV parse + ALSA device open. Those are gone from the hot path; audible latency drops from ~50–150 ms to a few ms.
  - **Tiny pre-beep** — that was the ALSA device's startup pop firing immediately before each play. By keeping the device open between shots (and pre-warming it with a short silence right after spawning), the pop only happens once, at launch, before the participant is listening.

## Changes
- [SonicSole_Audio.h](SonicSole_Audio.h) / [SonicSole_Audio.cpp](SonicSole_Audio.cpp):
  - Parse `beep.wav` once at startup into raw PCM + format metadata.
  - Spawn `aplay -q -t raw -c <channels> -r <rate> -f <format> -D <device> --buffer-time=50000 --period-time=10000` a single time, wired to a pipe whose write end we hold.
  - Push ~200 ms of silence through the pipe at startup so the ALSA device opens / its click fires before the game starts.
  - `play()` grabs the micro-timestamp and hands the PCM copy off to a detached writer thread that drains it into the pipe (the main loop never blocks on pipe back-pressure).
  - `close()` closes our write end; the child sees EOF and exits. `SIGCHLD` is masked with `SA_NOCLDWAIT` so the child auto-reaps — no zombies.

## Test plan
- [ ] On the Buster Pi: `git pull && ./compile_C_RPi_Andy.sh` — no new apt packages required.
- [ ] Startup log shows `[Audio] Persistent aplay ready: beep.wav (44100 Hz, 2 ch, 16-bit, <N> PCM bytes) on default` followed by a brief click (this is the warm-up — the one you used to hear *per shot*).
- [ ] Run through several reaction rounds — the beep should fire with noticeably less lag and no leading tick.
- [ ] Verify with `pgrep -fa aplay` while the RPi binary is up: exactly **one** aplay process, present from launch to shutdown.
- [ ] If the audio board isn't on `default`, override as before: `SONICSOLE_ALSA_DEVICE="plughw:CARD=<name>,DEV=0" ./run_RPi_combined.sh`.