### PR TITLE
Use anatomical insole silhouette in sensor check panel

### DIFF
--- a/web_page/templates/_sensor_check_panel.html
+++ b/web_page/templates/_sensor_check_panel.html
@@ -40,7 +40,7 @@
     <section class="sensor-check-page sensor-check-page--pressure sensor-panel sensor-panel--pressure">
       <h3>Pressure Sensors</h3>
       <div class="pressure-stage">
-        <svg class="pressure-insole" viewBox="0 0 280 780" role="img" aria-label="Live insole pressure gradient from heel to toe">
+        <svg class="pressure-insole" viewBox="0 0 38.92 96.27" role="img" aria-label="Live insole pressure gradient from heel to toe">
           <defs>
             <linearGradient id="pressureGradient" x1="50%" y1="100%" x2="50%" y2="0%">
               <stop id="heelGradientStop" offset="0%" stop-color="#ffffff"></stop>
@@ -49,10 +49,10 @@
             </linearGradient>
           </defs>
           <path
-            d="M140 20 C195 18 235 50 252 102 C270 156 264 226 243 291 C222 355 204 407 201 489 C198 559 208 633 198 700 C190 752 166 780 134 780 C102 780 77 752 70 702 C61 637 71 561 67 489 C64 408 46 355 25 291 C4 228 -2 158 17 102 C33 54 75 20 140 20 Z"
+            d="M16.92.25C2,.25-.08,23.27.29,29.16c.38,5.94,1.85,8.74,3.9,16.04,2.05,7.3,1.07,12.15.04,21.38-1.03,9.23-2.43,14.86-1.37,20.58,1.07,5.72,5.82,8.13,9.58,8.72.6.1,1.21.14,1.84.14,3.3,0,6.84-1.4,9.38-5.04,3.02-4.33,6.29-23.29,7.47-28.61s7.01-21.76,7.47-28.82c.47-7.05-1.06-16-6.14-23.84C27.38,1.87,20.88.34,17.3.25c-.13,0-.25,0-.38,0h0Z"
             fill="url(#pressureGradient)"
             stroke="#1f1f1f"
-            stroke-width="5"
+            stroke-width="0.7"
             stroke-linejoin="round"
           ></path>
         </svg>


### PR DESCRIPTION
## Summary
- Swap the placeholder foot outline in the shared sensor check panel (`_sensor_check_panel.html`) for the anatomical insole silhouette from the SVG asset library
- New `viewBox` is `0 0 38.92 96.27` with a scaled `stroke-width` of `0.7` to preserve the outline weight
- Applies to both surfaces that include the partial: setup guide (`assemblyInstructions.html`) and main group page (`phone_home.html`)

## Test plan
- [ ] Visit the setup guide sensor check step and confirm the insole outline looks like a real insole (arch cutout, rounded heel, wide forefoot)
- [ ] Visit a group's main page, open the sensor check sheet, and confirm the same insole outline renders
- [ ] With a connected device, confirm the heel/mid/forefoot pressure gradient still fills the new shape correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)