### PR TITLE
Let the phone QR page regenerate codes for a new server IP

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -2365,6 +2365,33 @@ def phone_group_qr_page():
     )
 
 
+@app.route('/phone/qr/image')
+def phone_group_qr_image():
+    import io
+    import qrcode
+
+    host = (request.args.get("host") or PHONE_QR_DEFAULT_HOST).strip()
+    slug = (request.args.get("slug") or "").strip()
+    if not slug:
+        abort(400)
+
+    url = f"http://{host}/phone/{slug}"
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=qrcode.constants.ERROR_CORRECT_M,
+        box_size=16,
+        border=2,
+    )
+    qr.add_data(url)
+    qr.make(fit=True)
+    image = qr.make_image(fill_color="black", back_color="white")
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    buffer.seek(0)
+    return send_file(buffer, mimetype="image/png")
+
+
 @app.route('/phone/<group_slug>')
 def phone_group_home(group_slug):
     return render_phone_group_home_page(group_slug)

--- a/web_page/templates/phone_qr.html
+++ b/web_page/templates/phone_qr.html
@@ -61,6 +61,15 @@
       border-radius: 8px;
       background: #fafafa;
       font-family: "SF Mono", "Menlo", "Consolas", monospace;
+      font-size: inherit;
+      min-width: 180px;
+      text-align: center;
+    }
+
+    .qr-actions .qr-host-value:focus {
+      outline: none;
+      border-color: #111;
+      background: #fff;
     }
 
     .qr-actions button {
@@ -139,15 +148,24 @@
         Each QR code opens the phone page for that group on the local Wi-Fi network. Make sure your phone is connected to the same Wi-Fi as the server.
       </p>
       <div class="qr-actions">
-        <span>Server:</span>
-        <span class="qr-host-value">{{ phone_qr_host }}</span>
+        <label for="qr-host-input">Server:</label>
+        <input
+          id="qr-host-input"
+          class="qr-host-value"
+          type="text"
+          value="{{ phone_qr_host }}"
+          spellcheck="false"
+          autocapitalize="off"
+          autocomplete="off"
+        />
+        <button type="button" id="qr-update-btn">Update QR Codes</button>
         <button type="button" onclick="window.print()">Print</button>
       </div>
     </header>
 
     <section class="qr-grid" aria-label="Group QR codes">
       {% for group in phone_qr_groups %}
-      <article class="qr-card">
+      <article class="qr-card" data-slug="{{ group.slug }}">
         <div class="qr-card__label">{{ group.label }}</div>
         <img class="qr-card__image" src="{{ group.qr_src }}" alt="QR code for {{ group.label }}" />
         <div class="qr-card__url">{{ group.url }}</div>
@@ -155,5 +173,42 @@
       {% endfor %}
     </section>
   </main>
+  <script>
+    (function () {
+      var input = document.getElementById('qr-host-input');
+      var button = document.getElementById('qr-update-btn');
+
+      function updateQrCodes() {
+        var host = (input.value || '').trim();
+        if (!host) {
+          input.focus();
+          return;
+        }
+        var cards = document.querySelectorAll('.qr-card');
+        cards.forEach(function (card) {
+          var slug = card.getAttribute('data-slug');
+          if (!slug) return;
+          var url = 'http://' + host + '/phone/' + slug;
+          var img = card.querySelector('.qr-card__image');
+          var urlEl = card.querySelector('.qr-card__url');
+          if (img) {
+            var params = new URLSearchParams({ host: host, slug: slug, t: Date.now().toString() });
+            img.src = '/phone/qr/image?' + params.toString();
+          }
+          if (urlEl) {
+            urlEl.textContent = url;
+          }
+        });
+      }
+
+      button.addEventListener('click', updateQrCodes);
+      input.addEventListener('keydown', function (event) {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          updateQrCodes();
+        }
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Made the server IP on `/phone/qr` an editable input with an "Update QR Codes" button (Enter in the input also triggers it).
- Added a `/phone/qr/image?host=<host>&slug=<slug>` Flask endpoint that renders a PNG in-memory using the existing `qrcode` library — no disk writes, no need to pre-run `generate_group_qr_codes.py` after a network change.
- Clicking "Update" rewrites each card's `img src` to hit the new endpoint with the typed host and refreshes the URL text underneath.

## Why
Switching Wi-Fi networks (different event, different router) used to mean editing `PHONE_QR_DEFAULT_HOST` and re-running the static-PNG generator. Now it's a page-level edit.

## Test plan
- [ ] Visit `http://127.0.0.1:5001/phone/qr` — the server field is editable and the original QR PNGs render.
- [ ] Change the IP (e.g. `192.168.1.10:5001`) and click **Update QR Codes** — each card's image and URL update to the new host.
- [ ] Press Enter inside the input — same behavior as the button.
- [ ] Scan a regenerated QR with a phone on the same network — it opens the expected `/phone/<group>` page.
- [ ] Print view still hides the actions and keeps the 2-column grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)