### PR TITLE
Require standing pressure before starting jump measurement

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1881,6 +1881,19 @@ def start_jump():
     session_id = create_activity_session("jump")
     reset_jump_state(cancel_session=False)
     start_combined_data_thread()
+
+    time.sleep(0.3)
+    try:
+        standing_pressure = int(received_heel_data) + int(received_fore_data)
+    except (TypeError, ValueError):
+        standing_pressure = 0
+    if standing_pressure <= 500:
+        reset_jump_state(cancel_session=True)
+        return jsonify({
+            'status': 'warning',
+            'message': f'Please stand on the insole before starting (pressure {standing_pressure} must be > 500).'
+        }), 400
+
     airtime, height, was_cancelled = get_airtime_and_height(session_id)
     if was_cancelled:
         return jsonify({'status': 'cancelled'})

--- a/web_page/templates/jump.html
+++ b/web_page/templates/jump.html
@@ -404,6 +404,9 @@
             return;
           }
           alert(error.message || "Unable to start jumping.");
+          if (jumpActivityToggle) {
+            jumpActivityToggle.deactivate();
+          }
         },
       });
     });


### PR DESCRIPTION
## Summary
- Gate `/start_jump` on a combined heel+fore pressure > 500 so the measurement only begins when the user is actually standing on the insole.
- Return a 400 warning ("Please stand on the insole before starting...") and cancel the just-created jump session when the check fails.
- Update the jump page toggle to call `deactivate()` after surfacing the alert, so the button returns to "Start" rather than being stuck on "Stop".

## Why
Jump takeoff detection fires when both heel and fore pressures drop below their thresholds. If `/start_jump` was triggered while the user wasn't on the insole, it would immediately "detect takeoff" and then wait forever for a landing. Requiring a standing pressure at the start prevents that failure mode and gives the user a clear warning.

## Test plan
- [ ] Start jump activity while NOT standing on the insole → expect an alert with the "Please stand..." warning and the button to reset to "Start".
- [ ] Start jump activity while standing on the insole → expect takeoff/landing detection to work as before and a jump height to be reported.
- [ ] Verify activity session is cleaned up (no lingering jump session) after a warning is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)