### PR TITLE
Narrow precision target force range to 500-1000

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1001,7 +1001,7 @@ forefoot_elapsed_time = 0
 
 PRECISION_FORCE_MAX = 2000
 PRECISION_CAPTURE_SECONDS = 5
-PRECISION_TARGET_PERCENTS = [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]
+PRECISION_TARGET_PERCENTS = [25, 30, 35, 40, 45, 50]
 
 precision_trainer_state = {
     'status': 'idle',


### PR DESCRIPTION
## Summary
- Reduce `PRECISION_TARGET_PERCENTS` in [web_page/app.py:1004](web_page/app.py:1004) from `[20, 25, ..., 95]` to `[25, 30, 35, 40, 45, 50]`.
- With `PRECISION_FORCE_MAX = 2000`, randomly selected precision targets now fall in `{500, 600, 700, 800, 900, 1000}` instead of spanning `400-1900`.

## Why
Caps the precision trainer's target force to the 500-1000 range so players aren't asked to hit very low or very high loads.

## Test plan
- [ ] Load the precision page, start a round, and confirm the displayed Target is one of 500/600/700/800/900/1000.
- [ ] Run multiple rounds to sanity-check the random pick stays inside the new range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)