### PR TITLE
Require standing pressure before starting balance measurement

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1998,6 +1998,19 @@ def button_click():
 
     session_id = create_balance_session()
     start_combined_data_thread()
+
+    time.sleep(0.3)
+    try:
+        standing_pressure = int(received_heel_data) + int(received_fore_data)
+    except (TypeError, ValueError):
+        standing_pressure = 0
+    if standing_pressure <= 500:
+        cancel_balance_session()
+        return jsonify({
+            'status': 'warning',
+            'message': f'Please stand on the insole before starting (pressure {standing_pressure} must be > 500).'
+        }), 400
+
     set_balance_status("countdown")
     # Visual countdown runs in the browser; audio cues are emitted by the RPi.
     time.sleep(3.12)

--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -395,6 +395,9 @@
           }
           alert(error.message || "Unable to start balancing.");
           console.error("Error:", error);
+          if (balanceActivityToggle) {
+            balanceActivityToggle.deactivate();
+          }
         },
       });
     });


### PR DESCRIPTION
## Summary
- Gate `/button_click` on a combined heel+fore pressure > 500 so balancing only starts when the user is actually on the insole.
- Cancel the balance session and return a 400 warning ("Please stand on the insole before starting...") when the check fails.
- Update the balance page toggle to call `deactivate()` after surfacing the alert, so the button returns to "Start" rather than being stuck on "Stop".

## Why
Mirrors the guard added for jump in [#15](https://github.com/SherimaX/SonicSole/pull/15). Without this, `/button_click` would happily start the 3-second countdown and ship `START balance` to the RPi even if the user's foot wasn't on the insole, leading to confusing "Try again" errors once the RPi timed out.

## Test plan
- [ ] Click Start on balance while NOT standing on the insole → expect an alert with the "Please stand..." warning and the button to reset to "Start" (no countdown runs to completion).
- [ ] Click Start on balance while standing on the insole → expect the countdown to run and balance timing to work as before.
- [ ] Verify the balance session is cleaned up (no lingering state) after a warning is returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)