### PR TITLE
Simplify standing-pressure warning message

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1891,7 +1891,7 @@ def start_jump():
         reset_jump_state(cancel_session=True)
         return jsonify({
             'status': 'warning',
-            'message': f'Please stand on the insole before starting (pressure {standing_pressure} must be > 500).'
+            'message': 'Please stand on the insole before starting.'
         }), 400
 
     airtime, height, was_cancelled = get_airtime_and_height(session_id)
@@ -2008,7 +2008,7 @@ def button_click():
         cancel_balance_session()
         return jsonify({
             'status': 'warning',
-            'message': f'Please stand on the insole before starting (pressure {standing_pressure} must be > 500).'
+            'message': 'Please stand on the insole before starting.'
         }), 400
 
     set_balance_status("countdown")


### PR DESCRIPTION
## Summary
- Drop the raw pressure value and threshold from the jump/balance standing-pressure warnings.
- Users now see a clean "Please stand on the insole before starting." instead of the debug-style "(pressure 123 must be > 500)" detail.

## Why
The numeric details in the previous message were noise for end users — the actionable instruction is all they need.

## Test plan
- [ ] Start jump while not on the insole → alert text reads "Please stand on the insole before starting." with no pressure value.
- [ ] Same for balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)