### PR TITLE
Center activity info button with SVG icon

### DIFF
--- a/web_page/static/playground-theme.css
+++ b/web_page/static/playground-theme.css
@@ -491,15 +491,14 @@ body > a[href]:hover {
   min-height: 48px !important;
   padding: 0 !important;
   border-radius: 50% !important;
-  font-family: "Georgia", "Times New Roman", serif !important;
-  font-style: italic;
-  font-size: 1.35rem !important;
-  line-height: 1;
+  line-height: 0;
 }
 
 .pg-info-btn__glyph {
-  display: inline-block;
-  transform: translateY(-1px);
+  width: 22px;
+  height: 22px;
+  display: block;
+  fill: currentColor;
 }
 
 .btn-outline,

--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -244,7 +244,10 @@
         <a href="{{ url_for('pc_scoreboard', board_key='balance') }}">Scoreboard</a>
         {% endif %}
         <button type="button" class="pg-info-btn" aria-label="Show balancing instructions" onclick="openInstructionsModal()">
-          <span class="pg-info-btn__glyph">i</span>
+          <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="5.5" r="1.7"/>
+            <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+          </svg>
         </button>
       </div>
     </div>

--- a/web_page/templates/foreWalk.html
+++ b/web_page/templates/foreWalk.html
@@ -208,7 +208,10 @@
     <div class="pg-header-nav">
       <a href="{{ url_for('w_scoreboard') }}" onclick="openScoreboardModal(); return false;">Scoreboard</a>
       <button type="button" class="pg-info-btn" aria-label="Show forefoot walk instructions" onclick="openInstructionsModal()">
-        <span class="pg-info-btn__glyph">i</span>
+        <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <circle cx="12" cy="5.5" r="1.7"/>
+          <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+        </svg>
       </button>
     </div>
   </div>
@@ -216,7 +219,10 @@
   <div class="pg-activity-toolbar">
     <div class="pg-header-nav">
       <button type="button" class="pg-info-btn" aria-label="Show forefoot walk instructions" onclick="openInstructionsModal()">
-        <span class="pg-info-btn__glyph">i</span>
+        <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+          <circle cx="12" cy="5.5" r="1.7"/>
+          <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+        </svg>
       </button>
     </div>
   </div>

--- a/web_page/templates/jump.html
+++ b/web_page/templates/jump.html
@@ -242,7 +242,10 @@
         <a href="{{ url_for('pc_scoreboard', board_key='jump') }}">Scoreboard</a>
         {% endif %}
         <button type="button" class="pg-info-btn" aria-label="Show jumping instructions" onclick="openInstructionsModal()">
-          <span class="pg-info-btn__glyph">i</span>
+          <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="5.5" r="1.7"/>
+            <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+          </svg>
         </button>
       </div>
     </div>

--- a/web_page/templates/precision.html
+++ b/web_page/templates/precision.html
@@ -318,7 +318,10 @@
         <a href="{{ url_for('pc_scoreboard', board_key='precision') }}">Scoreboard</a>
         {% endif %}
         <button type="button" class="pg-info-btn" aria-label="Show precision instructions" onclick="openInstructionsModal()">
-          <span class="pg-info-btn__glyph">i</span>
+          <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="5.5" r="1.7"/>
+            <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+          </svg>
         </button>
       </div>
     </div>

--- a/web_page/templates/reaction.html
+++ b/web_page/templates/reaction.html
@@ -226,7 +226,10 @@
         <a href="{{ url_for('pc_scoreboard', board_key='reaction') }}">Scoreboard</a>
         {% endif %}
         <button type="button" class="pg-info-btn" aria-label="Show reaction instructions" onclick="openInstructionsModal()">
-          <span class="pg-info-btn__glyph">i</span>
+          <svg class="pg-info-btn__glyph" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <circle cx="12" cy="5.5" r="1.7"/>
+            <rect x="10.3" y="9.2" width="3.4" height="11" rx="1.7"/>
+          </svg>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Replaces the italic-i text glyph inside the circular `.pg-info-btn` with a bounding-box-symmetric SVG icon (dot + rounded stem). Removes the Georgia-italic font stack, the `font-size` override, and the `transform: translateY(-1px)` hack that were nudging the letter off-center.

## Why
The italic "i" never sat perfectly centered in the 48 px circle — font metrics include ascender/descender space, so the visible glyph always drifted slightly up/left even with the 1 px translate fix. Using an SVG with geometry that is symmetric around (12, 12) in the viewBox lets flexbox center the icon cleanly on every browser.

## Notes for reviewer
- SVG uses `currentColor`, so the icon inherits the button's text color (same dark-on-light / light-on-dark treatment as before).
- Applied to all six button instances: jump, balance, reaction, precision, and foreWalk (the foreWalk toolbar renders in both group-locked and unlocked branches).
- Aria labels and `openInstructionsModal()` behavior are unchanged.

## Test plan
- [ ] Load jump / balance / reaction / precision / foreWalk — the info icon is visually centered inside the circle on desktop and phone layouts.
- [ ] Icon remains crisp at the retina/2x DPR.
- [ ] Hover / focus state still matches the Scoreboard button's treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)