### PR TITLE
Drop redundant close X from activity instructions modal

### DIFF
--- a/web_page/templates/_instructions_modal.html
+++ b/web_page/templates/_instructions_modal.html
@@ -18,20 +18,12 @@
   }
 
   .pg-instructions-modal__header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 16px;
     margin-bottom: 12px;
   }
 
   .pg-instructions-modal__title {
     margin: 0;
     font-size: 1.35rem;
-  }
-
-  .pg-instructions-modal__close {
-    flex: 0 0 auto;
   }
 
   .pg-instructions-modal__body {
@@ -50,14 +42,6 @@
   <div class="modal-content pg-instructions-modal__content">
     <div class="pg-instructions-modal__header">
       <h2 class="pg-instructions-modal__title">{{ instructions_title | default('How to Play') }}</h2>
-      <button
-        type="button"
-        class="pg-manage-close pg-instructions-modal__close"
-        aria-label="Close instructions"
-        onclick="closeInstructionsModal()"
-      >
-        &times;
-      </button>
     </div>
     <p class="pg-instructions-modal__body">{{ instructions_body | default('Follow the on-screen prompts to complete this activity.') }}</p>
   </div>


### PR DESCRIPTION
## Summary
Removes the floating `×` close button (and its CSS/flex layout) from the activity instructions modal. The modal still closes on backdrop click and on Escape — both handlers already live in `_instructions_modal.html` — so the X was redundant.

## Why
The × sat in the top-right of the instructions card and crowded short titles like "How to Jump". Removing it cleans up the header and leaves a single-child layout.

## Notes for reviewer
- Only `web_page/templates/_instructions_modal.html` changes.
- Close paths still working: `onclick="if (event.target === this) closeInstructionsModal();"` on the backdrop + the Escape keydown listener.

## Test plan
- [ ] Open the instructions modal on jump / balance / reaction / precision / foreWalk — no × in the corner, title sits flush-left.
- [ ] Click outside the card → modal closes.
- [ ] Press Escape → modal closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)