### PR TITLE
Auto-refresh PC scoreboard via polling

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -2599,6 +2599,29 @@ def pc_scoreboard(board_key="jump"):
     )
 
 
+@app.route('/api/scoreboard/<board_key>')
+def pc_scoreboard_data(board_key):
+    if board_key not in PC_SCOREBOARD_KEYS:
+        abort(404)
+
+    scoreboard_rows = load_group_best_performance(board_key)
+    populated_rows = [row for row in scoreboard_rows if row["has_score"]]
+    leaderboard_config = get_leaderboard_config(board_key)
+    leader_group_id = None
+
+    if populated_rows:
+        if leaderboard_config["sort_reverse"]:
+            leader_group_id = max(populated_rows, key=lambda row: row["score"])["group_id"]
+        else:
+            leader_group_id = min(populated_rows, key=lambda row: row["score"])["group_id"]
+
+    return jsonify({
+        "rows": scoreboard_rows,
+        "leader_group_id": leader_group_id,
+        "sort_reverse": leaderboard_config["sort_reverse"],
+    })
+
+
 @app.route('/bScoreboard')
 def b_scoreboard():
     return render_template(

--- a/web_page/templates/scoreboard.html
+++ b/web_page/templates/scoreboard.html
@@ -255,12 +255,77 @@
       header.addEventListener("keydown", handleScoreboardHeaderKeydown);
     });
 
-    getScoreboardRows().forEach((row) => {
+    function wireScoreboardRow(row) {
       row.addEventListener("click", () => openScoreboardRowHistory(row));
       row.addEventListener("keydown", handleScoreboardRowKeydown);
-    });
+    }
+
+    getScoreboardRows().forEach(wireScoreboardRow);
 
     updateScoreboardHeaderState();
+
+    const scoreboardBoardKey = {{ scoreboard_activity.slug | tojson }};
+    const scoreboardRefreshUrl = "/api/scoreboard/" + encodeURIComponent(scoreboardBoardKey);
+    const SCOREBOARD_REFRESH_MS = 3000;
+
+    function orderRowsForCurrentSort(rows) {
+      const { key, direction } = scoreboardSortState;
+      return rows.slice().sort((rowA, rowB) => {
+        if (key === "group") {
+          const diff = getRowNumberValue(rowA) - getRowNumberValue(rowB);
+          return direction === "asc" ? diff : -diff;
+        }
+        const scoreA = getRowScoreValue(rowA);
+        const scoreB = getRowScoreValue(rowB);
+        if (scoreA === null && scoreB === null) return getRowNumberValue(rowA) - getRowNumberValue(rowB);
+        if (scoreA === null) return 1;
+        if (scoreB === null) return -1;
+        if (scoreA === scoreB) return getRowNumberValue(rowA) - getRowNumberValue(rowB);
+        return direction === "asc" ? scoreA - scoreB : scoreB - scoreA;
+      });
+    }
+
+    function refreshScoreboard(payload) {
+      const rowsById = new Map();
+      getScoreboardRows().forEach((row) => rowsById.set(row.dataset.groupId, row));
+
+      const leaderId = payload.leader_group_id;
+      const updatedRows = [];
+
+      (payload.rows || []).forEach((rowData) => {
+        const row = rowsById.get(rowData.group_id);
+        if (!row) return;
+
+        const scoreCell = row.children[1];
+        const formatted = rowData.formatted_score || "--";
+        if (scoreCell && scoreCell.textContent !== formatted) {
+          scoreCell.textContent = formatted;
+        }
+        row.dataset.score = rowData.score === null || rowData.score === undefined ? "" : String(rowData.score);
+        row.classList.toggle("pg-scoreboard-table__row--leader", Boolean(leaderId) && rowData.group_id === leaderId);
+        updatedRows.push(row);
+      });
+
+      orderRowsForCurrentSort(updatedRows).forEach((row) => scoreboardTableBody.appendChild(row));
+    }
+
+    async function pollScoreboard() {
+      try {
+        const response = await fetch(scoreboardRefreshUrl, { cache: "no-store" });
+        if (!response.ok) return;
+        const payload = await response.json();
+        refreshScoreboard(payload);
+      } catch (error) {
+        // Network blip — try again on the next tick.
+      }
+    }
+
+    setInterval(pollScoreboard, SCOREBOARD_REFRESH_MS);
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") {
+        pollScoreboard();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add `/api/scoreboard/<board_key>` JSON endpoint returning group rows, the current leader id, and the sort direction.
- Poll that endpoint every 3s from `scoreboard.html` and update each row's score, `data-score`, and leader highlight in place — preserving event wiring and the user's active sort.
- Also fire an immediate refresh when the tab regains focus, so switching back to the scoreboard shows current numbers without waiting for the next tick.

## Why
The PC scoreboard previously only refreshed on a full page reload. Operators running an event had to manually reload to see new group scores as activities completed. This change makes the board update on its own while groups keep playing.

## Scope note
Only the modern `/scoreboard/<board_key>` view is wired up. The legacy `/bScoreboard`, `/jScoreboard`, `/rScoreboard`, `/pScoreboard`, `/wScoreboard` templates are untouched.

## Test plan
- [ ] Open `/scoreboard/jump`, append a row to `SonicSoleJump.txt` for an existing group, and confirm the score + leader row update within ~3s without reload.
- [ ] Click the Performance header to sort descending, then trigger a refresh — sort direction should persist.
- [ ] Switch to another tab and back; verify the board refreshes immediately on refocus.
- [ ] Repeat for `/scoreboard/balance`, `/scoreboard/reaction`, `/scoreboard/precision` (different sort directions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)