### PR TITLE
Auto-connect Wi-Fi + autostart combined sender at boot

### DIFF
--- a/boot_wifi_then_run.sh
+++ b/boot_wifi_then_run.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# boot_wifi_then_run.sh
+#
+# Boot-time launcher for SonicSole:
+#   1. Wait for wlan0.
+#   2. Loop until connected to Wi-Fi SSID "SonicSole" (retries forever).
+#   3. Play beep.wav to signal success.
+#   4. Exec ./run_RPi_combined.sh so it becomes the main process.
+#
+# Designed to be started by systemd (see sonicsole.service).
+# Safe to run manually for testing: sudo ./boot_wifi_then_run.sh
+#
+
+set -u
+
+TARGET_SSID="SonicSole"
+RETRY_SECS=5
+IFACE="wlan0"
+
+# Resolve script directory so this works regardless of cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+BEEP="$SCRIPT_DIR/beep.wav"
+MAIN_SCRIPT="$SCRIPT_DIR/run_RPi_combined.sh"
+
+log() { echo "[boot_wifi] $(date '+%F %T') $*"; }
+
+# --- Detect which Wi-Fi stack is in use ---------------------------------------
+have_nmcli=0
+if command -v nmcli >/dev/null 2>&1 && systemctl is-active --quiet NetworkManager; then
+    have_nmcli=1
+fi
+
+current_ssid() {
+    # Prefer iwgetid (works with both NM and wpa_supplicant), fall back to nmcli.
+    if command -v iwgetid >/dev/null 2>&1; then
+        iwgetid -r 2>/dev/null
+    elif [ "$have_nmcli" -eq 1 ]; then
+        nmcli -t -f active,ssid dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}'
+    fi
+}
+
+try_connect() {
+    if [ "$have_nmcli" -eq 1 ]; then
+        # Assumes a connection profile named "SonicSole" already exists.
+        # Create it once with:
+        #   sudo nmcli connection add type wifi con-name SonicSole ifname wlan0 ssid SonicSole
+        #   sudo nmcli connection modify SonicSole wifi-sec.key-mgmt wpa-psk wifi-sec.psk 'PASSWORD'
+        #   sudo nmcli connection modify SonicSole connection.autoconnect yes
+        nmcli -w 20 connection up SonicSole >/dev/null 2>&1
+    else
+        # wpa_supplicant path: ask it to re-scan/reconnect.
+        wpa_cli -i "$IFACE" reconfigure >/dev/null 2>&1
+        wpa_cli -i "$IFACE" reconnect   >/dev/null 2>&1
+    fi
+}
+
+# --- 1. Wait for the Wi-Fi interface to appear --------------------------------
+log "Waiting for interface $IFACE ..."
+for _ in $(seq 1 60); do
+    ip link show "$IFACE" >/dev/null 2>&1 && break
+    sleep 1
+done
+
+# --- 2. Retry until we are on the target SSID ---------------------------------
+log "Target SSID: $TARGET_SSID"
+while : ; do
+    ssid="$(current_ssid)"
+    if [ "$ssid" = "$TARGET_SSID" ]; then
+        log "Connected to $TARGET_SSID."
+        break
+    fi
+    log "Not connected (current: '${ssid:-none}'). Retrying in ${RETRY_SECS}s."
+    try_connect
+    sleep "$RETRY_SECS"
+done
+
+# --- 3. Play success beep (non-fatal if audio device isn't ready) -------------
+if [ -f "$BEEP" ] && command -v aplay >/dev/null 2>&1; then
+    aplay -q "$BEEP" </dev/null >/dev/null 2>&1 || log "Beep failed (continuing)."
+else
+    log "No beep.wav or aplay missing; skipping sound."
+fi
+
+# --- 4. Hand off to the main script -------------------------------------------
+if [ ! -x "$MAIN_SCRIPT" ]; then
+    log "ERROR: $MAIN_SCRIPT not executable. chmod +x it."
+    exit 1
+fi
+
+log "Launching $MAIN_SCRIPT"
+exec "$MAIN_SCRIPT"

--- a/sonicsole.service
+++ b/sonicsole.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=SonicSole boot: connect Wi-Fi then run combined sender
+After=network.target sound.target
+# Don't use network-online.target here: we WANT to run even when offline,
+# since the script itself handles the wait-for-Wi-Fi loop.
+
+[Service]
+Type=simple
+User=root
+# Edit WorkingDirectory to match where the repo lives on the Pi.
+WorkingDirectory=/root/SonicSole
+ExecStart=/root/SonicSole/boot_wifi_then_run.sh
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Add `boot_wifi_then_run.sh`: on boot, waits for `wlan0`, loops every 5 s until the Pi is associated with SSID `SonicSole` (uses `nmcli connection up SonicSole` with a `wpa_cli reconnect` fallback for legacy Pi OS), plays `beep.wav` via `aplay` on success, then `exec`s `run_RPi_combined.sh`.
- Add `sonicsole.service`: systemd unit that starts the script at boot and restarts on failure. Uses `After=network.target sound.target` (not `network-online.target`) so the script itself owns the retry loop — the Pi keeps trying forever if the AP isn't up yet.

## Why
Lets a headless Pi come up, grab the SonicSole AP whenever it appears, audibly confirm the connection, and then launch the combined sender without any manual steps.

## Install on the Pi (one-time)
```bash
# Create the NM profile once so the script has something to bring up:
sudo nmcli connection add type wifi con-name SonicSole ifname wlan0 ssid SonicSole
sudo nmcli connection modify SonicSole wifi-sec.key-mgmt wpa-psk wifi-sec.psk 'YOUR_PASSWORD'
sudo nmcli connection modify SonicSole connection.autoconnect yes

# Install unit (edit WorkingDirectory/ExecStart paths first if repo isn't at /root/SonicSole):
sudo cp sonicsole.service /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now sonicsole.service
journalctl -u sonicsole -f
```

## Reviewer notes
- `sonicsole.service` defaults to `User=root` and `WorkingDirectory=/root/SonicSole` — these need adjusting to match wherever the repo lives on the target Pi. If running as `pi`, also `usermod -aG audio pi`.
- The script `exec`s the main program so systemd tracks the real process, not a wrapper.
- Retry interval is a constant near the top of the script (`RETRY_SECS=5`).

## Test plan
- [ ] Copy both files to the Pi, install the NM profile and systemd unit as above.
- [ ] With the SonicSole AP off, reboot the Pi and confirm `journalctl -u sonicsole -f` shows the retry loop.
- [ ] Turn on the AP and confirm: log shows "Connected to SonicSole", beep plays, `run_RPi_combined.sh` launches.
- [ ] `sudo systemctl restart sonicsole` while already associated — should connect immediately, beep, and launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)