### PR TITLE
Add boot-wait note after battery connection step

### DIFF
--- a/web_page/templates/assemblyInstructions.html
+++ b/web_page/templates/assemblyInstructions.html
@@ -2126,7 +2126,12 @@
               <li>
                 Open the <span class="clickable" onclick="openModal('CaseImageModal')">3D printed case</span>.
               </li>
-              <li>Connect the battery.</li>
+              <li>
+                Connect the battery.
+                <span class="step-note">
+                  Wait 3 to 5 minutes for the board to boot up before continuing.
+                </span>
+              </li>
               <li>
                 Place the <span class="clickable" onclick="openModal('PCBImageModal')">PCB board</span>
                 back into the <span class="clickable" onclick="openModal('CaseImageModal')">case</span>.


### PR DESCRIPTION
## Summary
Adds a step-note under *Connect the battery* on the **Install the Hardware** slide so users wait for the board to finish booting before moving on.

> Wait 3 to 5 minutes for the board to boot up before continuing.

## Why
Users were continuing the assembly before the system had finished booting, causing later steps (Sensor Check, plugging in the insole) to appear broken.

## Test plan
- [ ] Open \`/assemblyInstructions\`, advance to **Install the Hardware**, and confirm the note renders under step 2 in the existing \`.step-note\` style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)