### PR TITLE
Show server URL on startup so silenced Flask isn't mistaken for a hang

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -2954,4 +2954,21 @@ def button():
 if __name__ == '__main__':
     start_discovery_listener()
     flask_port = int(os.environ.get("SONICSOLE_PORT", os.environ.get("PORT", "5001")))
+
+    lan_ips = []
+    try:
+        probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        probe.settimeout(0.2)
+        probe.connect(("192.168.1.1", 1))
+        lan_ips.append(probe.getsockname()[0])
+        probe.close()
+    except OSError:
+        pass
+
+    print(f" * SonicSole server starting on port {flask_port}", flush=True)
+    print(f" * Local:   http://127.0.0.1:{flask_port}", flush=True)
+    for ip in lan_ips:
+        print(f" * Network: http://{ip}:{flask_port}", flush=True)
+    print(" * (werkzeug request logs are silenced; press Ctrl+C to stop)", flush=True)
+
     app.run(host='0.0.0.0', port=flask_port, debug=False)


### PR DESCRIPTION
## Summary

- Running `python3 web_page/app.py` printed nothing and looked frozen, especially on the offline SonicSole router where users assumed an online-resource dependency.
- Root cause: [app.py:20](web_page/app.py#L20) does `logging.getLogger('werkzeug').disabled = True` to quiet per-request spam, which also swallows Flask's "Running on http://..." banner. The server was running the whole time — it was just silent.
- Fix: print an explicit banner in the `__main__` block with the port, loopback URL, and the LAN URL (derived via a UDP `connect()` trick that only consults the kernel routing table — no packet, no DNS, fully offline-safe).

## Why not just unsilence werkzeug?
Keeping request logs off was intentional. Printing our own banner preserves that while still giving the user immediate confirmation that the server is up and at which address to point phones.

## Test plan
- [ ] `python3 web_page/app.py` — terminal immediately shows `* Local:` and `* Network:` lines
- [ ] Visit the printed `Network` URL from a phone on the SonicSole network — home page loads
- [ ] Router with no internet: banner still appears (probe `connect()` hits the local default gateway, no DNS)
- [ ] `SONICSOLE_PORT=5055 python3 web_page/app.py` — banner reflects the overridden port