### PR TITLE
Buster support for boot Wi-Fi script; disable power save to fix intermittent UDP

### DIFF
--- a/boot_wifi_then_run.sh
+++ b/boot_wifi_then_run.sh
@@ -2,93 +2,193 @@
 #
 # boot_wifi_then_run.sh
 #
-# Boot-time launcher for SonicSole:
-#   1. Wait for wlan0.
-#   2. Loop until connected to Wi-Fi SSID "SonicSole" (retries forever).
-#   3. Play beep.wav to signal success.
-#   4. Exec ./run_RPi_combined.sh so it becomes the main process.
+# Boot-time launcher + persistent Wi-Fi watchdog for SonicSole.
+#   1. Wait for wlan0 to appear.
+#   2. Loop until associated with SSID "SonicSole" (open network).
+#   3. Play beep.wav on (re)connect.
+#   4. Launch ./run_RPi_combined.sh.
+#   5. Fork a background watchdog that keeps monitoring for the lifetime of
+#      the service: if the Pi drops off SonicSole, it re-selects that network
+#      and keeps retrying until it's back, then beeps again.
 #
-# Designed to be started by systemd (see sonicsole.service).
-# Safe to run manually for testing: sudo ./boot_wifi_then_run.sh
+# Works on Raspbian Buster (wpa_supplicant, no NetworkManager) and on newer
+# releases that have nmcli. Designed to run via systemd (sonicsole.service).
+# The SonicSole network is expected to already exist in
+# /etc/wpa_supplicant/wpa_supplicant.conf (the user set it up once; we never
+# touch that file or need a password).
 #
 
 set -u
 
 TARGET_SSID="SonicSole"
-RETRY_SECS=5
 IFACE="wlan0"
+RETRY_SECS=5          # delay between reconnect attempts
+MONITOR_SECS=10       # watchdog poll interval
 
-# Resolve script directory so this works regardless of cwd.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 BEEP="$SCRIPT_DIR/beep.wav"
 MAIN_SCRIPT="$SCRIPT_DIR/run_RPi_combined.sh"
 
-log() { echo "[boot_wifi] $(date '+%F %T') $*"; }
+log() { echo "[boot_wifi] $(date '+%F %T') $*" >&2; }
 
-# --- Detect which Wi-Fi stack is in use ---------------------------------------
+# --- Pick the right Wi-Fi CLI -------------------------------------------------
+# Prefer nmcli when NetworkManager is active; otherwise fall back to wpa_cli.
+# wpa_cli lives in /sbin on Buster which isn't in pi's default PATH, so we
+# resolve an absolute path.
 have_nmcli=0
-if command -v nmcli >/dev/null 2>&1 && systemctl is-active --quiet NetworkManager; then
+if command -v nmcli >/dev/null 2>&1 && systemctl is-active --quiet NetworkManager 2>/dev/null; then
     have_nmcli=1
 fi
 
+WPA_CLI=""
+if [ "$have_nmcli" -eq 0 ]; then
+    for p in /sbin/wpa_cli /usr/sbin/wpa_cli /usr/bin/wpa_cli wpa_cli; do
+        if command -v "$p" >/dev/null 2>&1 || [ -x "$p" ]; then
+            WPA_CLI="$p"
+            break
+        fi
+    done
+    # wpa_cli control socket requires being in group 'netdev' or running as
+    # root. systemd should launch us as a user that qualifies.
+fi
+
 current_ssid() {
-    # Prefer iwgetid (works with both NM and wpa_supplicant), fall back to nmcli.
-    if command -v iwgetid >/dev/null 2>&1; then
-        iwgetid -r 2>/dev/null
-    elif [ "$have_nmcli" -eq 1 ]; then
-        nmcli -t -f active,ssid dev wifi 2>/dev/null | awk -F: '$1=="yes"{print $2; exit}'
+    if [ "$have_nmcli" -eq 1 ]; then
+        nmcli -t -f active,ssid dev wifi 2>/dev/null \
+            | awk -F: '$1=="yes"{print $2; exit}'
+    elif [ -n "$WPA_CLI" ]; then
+        "$WPA_CLI" -i "$IFACE" status 2>/dev/null \
+            | awk -F= '$1=="ssid"{print $2; exit}'
     fi
+}
+
+sonicsole_net_id() {
+    [ -n "$WPA_CLI" ] || return 0
+    # list_networks output:
+    #   network id / ssid / bssid / flags
+    #   0\tSomeSSID\tany\t[DISABLED]
+    "$WPA_CLI" -i "$IFACE" list_networks 2>/dev/null \
+        | awk -F'\t' -v s="$TARGET_SSID" 'NR>1 && $2==s {print $1; exit}'
 }
 
 try_connect() {
     if [ "$have_nmcli" -eq 1 ]; then
-        # Assumes a connection profile named "SonicSole" already exists.
-        # Create it once with:
-        #   sudo nmcli connection add type wifi con-name SonicSole ifname wlan0 ssid SonicSole
-        #   sudo nmcli connection modify SonicSole wifi-sec.key-mgmt wpa-psk wifi-sec.psk 'PASSWORD'
-        #   sudo nmcli connection modify SonicSole connection.autoconnect yes
-        nmcli -w 20 connection up SonicSole >/dev/null 2>&1
+        nmcli -w 20 connection up "$TARGET_SSID" >/dev/null 2>&1
+        return
+    fi
+    [ -n "$WPA_CLI" ] || return 0
+    local id
+    id="$(sonicsole_net_id)"
+    if [ -n "$id" ]; then
+        # select_network enables only this network in the current session,
+        # so wpa_supplicant keeps retrying SonicSole specifically.
+        "$WPA_CLI" -i "$IFACE" select_network "$id" >/dev/null 2>&1
     else
-        # wpa_supplicant path: ask it to re-scan/reconnect.
-        wpa_cli -i "$IFACE" reconfigure >/dev/null 2>&1
-        wpa_cli -i "$IFACE" reconnect   >/dev/null 2>&1
+        "$WPA_CLI" -i "$IFACE" reassociate >/dev/null 2>&1
     fi
 }
 
-# --- 1. Wait for the Wi-Fi interface to appear --------------------------------
+play_beep() {
+    if [ -f "$BEEP" ] && command -v aplay >/dev/null 2>&1; then
+        aplay -q "$BEEP" </dev/null >/dev/null 2>&1 || \
+            log "beep failed (continuing)"
+    fi
+}
+
+# Turn off Wi-Fi power save. The BCM radio on the Pi parks itself between
+# beacons when traffic is quiet; that batches outgoing UDP and makes the
+# sender look intermittent. Interactive SSH sessions mask this because they
+# keep the radio busy. Safe to re-run; silent on older kernels without iw.
+disable_wifi_powersave() {
+    local iw_bin=""
+    for p in /sbin/iw /usr/sbin/iw /usr/bin/iw iw; do
+        if [ -x "$p" ] || command -v "$p" >/dev/null 2>&1; then
+            iw_bin="$p"; break
+        fi
+    done
+    # `iw set` needs CAP_NET_ADMIN. When the service is started by systemd with
+    # AmbientCapabilities=CAP_NET_ADMIN this works as pi user directly; when
+    # run manually, fall through to sudo -n.
+    _try_iw() {
+        local bin="$1"
+        "$bin" dev "$IFACE" set power_save off >/dev/null 2>&1 && return 0
+        sudo -n "$bin" dev "$IFACE" set power_save off >/dev/null 2>&1
+    }
+    if [ -n "$iw_bin" ] && _try_iw "$iw_bin"; then
+        log "Wi-Fi power save off."
+        return 0
+    fi
+    # Fallback: iwconfig is available on some images even when iw isn't.
+    if command -v iwconfig >/dev/null 2>&1; then
+        if iwconfig "$IFACE" power off >/dev/null 2>&1 \
+           || sudo -n iwconfig "$IFACE" power off >/dev/null 2>&1; then
+            log "Wi-Fi power save off (via iwconfig)."
+            return 0
+        fi
+    fi
+    log "Wi-Fi power save toggle failed (continuing)."
+}
+
+wait_until_connected() {
+    while : ; do
+        local ssid
+        ssid="$(current_ssid)"
+        if [ "$ssid" = "$TARGET_SSID" ]; then
+            return 0
+        fi
+        log "Not connected (current: '${ssid:-none}'). Retrying in ${RETRY_SECS}s."
+        try_connect
+        sleep "$RETRY_SECS"
+    done
+}
+
+# --- 1. Wait for interface ----------------------------------------------------
 log "Waiting for interface $IFACE ..."
 for _ in $(seq 1 60); do
     ip link show "$IFACE" >/dev/null 2>&1 && break
     sleep 1
 done
 
-# --- 2. Retry until we are on the target SSID ---------------------------------
-log "Target SSID: $TARGET_SSID"
-while : ; do
-    ssid="$(current_ssid)"
-    if [ "$ssid" = "$TARGET_SSID" ]; then
-        log "Connected to $TARGET_SSID."
-        break
-    fi
-    log "Not connected (current: '${ssid:-none}'). Retrying in ${RETRY_SECS}s."
-    try_connect
-    sleep "$RETRY_SECS"
-done
+# --- 2. Initial connect -------------------------------------------------------
+log "Target SSID: $TARGET_SSID (nmcli=$have_nmcli, wpa_cli=${WPA_CLI:-none})"
+wait_until_connected
+log "Connected to $TARGET_SSID."
+disable_wifi_powersave
+play_beep
 
-# --- 3. Play success beep (non-fatal if audio device isn't ready) -------------
-if [ -f "$BEEP" ] && command -v aplay >/dev/null 2>&1; then
-    aplay -q "$BEEP" </dev/null >/dev/null 2>&1 || log "Beep failed (continuing)."
-else
-    log "No beep.wav or aplay missing; skipping sound."
-fi
+# --- 3. Background watchdog: reconnect forever --------------------------------
+(
+    while : ; do
+        sleep "$MONITOR_SECS"
+        ssid="$(current_ssid)"
+        if [ "$ssid" != "$TARGET_SSID" ]; then
+            log "[watchdog] lost connection (current: '${ssid:-none}'); reconnecting"
+            wait_until_connected
+            log "[watchdog] reconnected to $TARGET_SSID"
+            disable_wifi_powersave
+            play_beep
+        fi
+    done
+) &
+WATCHDOG_PID=$!
+log "Watchdog running (pid $WATCHDOG_PID)."
 
-# --- 4. Hand off to the main script -------------------------------------------
+cleanup() {
+    kill "$WATCHDOG_PID" 2>/dev/null || true
+    wait "$WATCHDOG_PID" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# --- 4. Run main program ------------------------------------------------------
 if [ ! -x "$MAIN_SCRIPT" ]; then
-    log "ERROR: $MAIN_SCRIPT not executable. chmod +x it."
+    log "ERROR: $MAIN_SCRIPT not executable."
     exit 1
 fi
 
 log "Launching $MAIN_SCRIPT"
-exec "$MAIN_SCRIPT"
+"$MAIN_SCRIPT"
+rc=$?
+log "Main exited (rc=$rc)."
+exit "$rc"

--- a/sonicsole.service
+++ b/sonicsole.service
@@ -1,18 +1,27 @@
 [Unit]
-Description=SonicSole boot: connect Wi-Fi then run combined sender
+Description=SonicSole boot: connect Wi-Fi, beep, run combined sender, keep Wi-Fi up
 After=network.target sound.target
-# Don't use network-online.target here: we WANT to run even when offline,
-# since the script itself handles the wait-for-Wi-Fi loop.
+# Don't use network-online.target: we WANT to run even when offline, because
+# the script itself owns the wait-for-Wi-Fi loop and the reconnect watchdog.
 
 [Service]
 Type=simple
-User=root
-# Edit WorkingDirectory to match where the repo lives on the Pi.
-WorkingDirectory=/root/SonicSole
-ExecStart=/root/SonicSole/boot_wifi_then_run.sh
+User=pi
+Group=pi
+# Keep environment minimal but ensure /sbin is on PATH so bare `wpa_cli` works
+# (the script also hard-codes the absolute path as a belt-and-braces).
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+WorkingDirectory=/home/pi/Desktop/SonicSole/git
+ExecStart=/home/pi/Desktop/SonicSole/git/boot_wifi_then_run.sh
+# Let the service toggle Wi-Fi power save without needing sudo.
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW CAP_SYS_NICE CAP_DAC_READ_SEARCH
 Restart=on-failure
 RestartSec=5
-StandardOutput=journal
+# Sender prints ~9 lines per cycle at several kHz. Feeding that into journald
+# creates back-pressure that can stall the sender's UDP loop. Drop stdout and
+# keep stderr on journal so real errors are still visible.
+StandardOutput=null
 StandardError=journal
 
 [Install]


### PR DESCRIPTION
## Summary
Follow-up to #27 after testing on the actual Pi (Raspbian Buster, kernel 5.10). Fixes three real problems found during deployment:

- **Intermittent UDP data from the sender.** `iw dev wlan0 get power_save` was `on`. When an SSH session is live the radio stays awake; at boot (no shell), the BCM chip parks itself between beacons and batches outgoing UDP, making the sender look intermittent from the server side. The script now runs `iw dev wlan0 set power_save off` immediately after each (re)connect.
- **Buster has no NetworkManager and no `iwgetid`.** The original fallback silently no-op'd. Rewrote Wi-Fi handling to probe `nmcli` first and fall back to `/sbin/wpa_cli`; SSID detection now parses `wpa_cli status`, and reconnect uses `select_network` on whichever list_networks row has `ssid=SonicSole`.
- **Journal back-pressure could stall the sender loop.** `SonicSole_RPi` prints ~9 lines per cycle at multi-kHz rates. Piped into journald via `StandardOutput=journal` this can create write-side back-pressure and stall the UDP loop. Switched to `StandardOutput=null`, moved the script's own `log()` output to stderr so boot-flow messages remain visible in `journalctl -u sonicsole`.

Also added:
- A **persistent watchdog subshell** inside the boot script. It polls the current SSID every 10 s for the lifetime of the service; if the Pi drops off SonicSole it keeps retrying and plays `beep.wav` on reconnect — not just once at boot.
- `AmbientCapabilities=CAP_NET_ADMIN` on the unit so the pi-user service can toggle power save without sudo; `CapabilityBoundingSet` narrows what else it can do.
- Service now runs as `User=pi` (pi is already in `netdev`, `audio`, `gpio`, so no root needed) with an explicit `PATH=` so bare `wpa_cli` resolves.

## Verification on the Pi (192.168.2.5)
- `/sbin/iw dev wlan0 get power_save` → `Power save: off` after boot (was `on` before).
- `systemctl is-active sonicsole` → `active`; exactly one `SonicSole_RPi` PID.
- Journal shows the expected sequence:
  ```
  [boot_wifi] Waiting for interface wlan0 ...
  [boot_wifi] Target SSID: SonicSole (nmcli=0, wpa_cli=/sbin/wpa_cli)
  [boot_wifi] Connected to SonicSole.
  [boot_wifi] Wi-Fi power save off.
  [boot_wifi] Watchdog running (pid …).
  [boot_wifi] Launching .../run_RPi_combined.sh
  ```
- UDP sockets confirmed via `ss -tulnp`: sender listens on `0.0.0.0:21010` (activity commands) and sends from `0.0.0.0:47000` to the discovered server at `192.168.2.1`.

## Reviewer notes
- `AmbientCapabilities=CAP_NET_ADMIN` requires systemd ≥ 229 (Buster has 241, fine).
- `select_network` only affects the running `wpa_supplicant` session — it doesn't call `save_config`, so reboot reloads the full saved network list.
- The `boot_wifi_then_run.sh` file may show two entries in `ps` (main + watchdog subshell). That's one logical service, not a duplicate sender; only `run_RPi_combined.sh`/`SonicSole_RPi` is the actual sender.

## Test plan
- [ ] Reboot the Pi cold (no SSH) and confirm the sender comes up, data arrives steadily at the server, and `iw get power_save` is `off`.
- [ ] Toggle the AP off for 30 s: confirm watchdog logs "lost connection", Pi re-associates when AP returns, beep plays, sender keeps running.
- [ ] `journalctl -u sonicsole -f` during normal operation: only `[boot_wifi]` + infrequent watchdog lines; no multi-kHz sender spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)