### PR TITLE
Fix concurrent activity interference (multi-tab session sharing + UDP-thread teardown)

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -513,8 +513,47 @@ def activate_selected_group():
     return selected_group
 
 
+def _group_id_from_request():
+    """Pick up an explicit group_id from the request (query first, then form/JSON).
+
+    Activity-start endpoints accept this so concurrent tabs in the same browser
+    don't collide on the shared Flask session cookie — each tab passes its own
+    `group_id` instead of relying on whichever group was last selected globally.
+    """
+    requested = (request.args.get("group_id") or "").strip()
+    if requested:
+        return requested
+    requested = (request.form.get("group_id") or "").strip()
+    if requested:
+        return requested
+    payload = request.get_json(silent=True) or {}
+    if isinstance(payload, dict):
+        requested = (payload.get("group_id") or "").strip()
+        if requested:
+            return requested
+    return ""
+
+
 def require_selected_group():
-    selected_group = get_selected_group()
+    """Resolve the group an activity should target.
+
+    Prefers an explicit `group_id` from the request — that lets per-tab JS
+    pin the start to the tab's own group. Falls back to the session-bound
+    selection for legacy callers and the desktop single-board flow.
+    """
+    requested_group_id = _group_id_from_request()
+    selected_group = None
+    if requested_group_id:
+        raw_group = GROUP_OPTIONS_BY_ID.get(requested_group_id)
+        if raw_group is None:
+            return None, (
+                jsonify({"status": "error", "message": "Unknown group selection."}),
+                400,
+            )
+        selected_group = build_group_option(raw_group)
+    else:
+        selected_group = get_selected_group()
+
     if selected_group is None:
         return None, (
             jsonify(
@@ -540,19 +579,7 @@ def require_selected_group():
             400,
         )
 
-    selected_group = activate_selected_group()
-    if selected_group is not None:
-        return selected_group, None
-
-    return None, (
-        jsonify(
-            {
-                "status": "error",
-                "message": "Unable to activate the selected group.",
-            }
-        ),
-        400,
-    )
+    return selected_group, None
 
 
 def get_group_name_from_request(*preferred_fields):
@@ -2290,8 +2317,9 @@ def run_precision_trainer(session_id, device_ip):
             error_percent=round(precision_error_value, 1),
             status="done",
         )
-    finally:
-        stop_combined_data_thread()
+    # Intentionally do NOT stop the UDP thread here — other boards may still be
+    # mid-activity and need fresh sensor snapshots. The thread is stopped only
+    # by /stop_data (the global panic button).
 
 @app.route('/precision_trainer_results')
 def precision_trainer_results():
@@ -2351,11 +2379,9 @@ def start_forefoot():
                 status="invalid",
                 time=elapsed_time,
             )
-            stop_combined_data_thread()
             return jsonify({"status": "invalid", "time": elapsed_time})
         ax_list.append(snapshot["ax"])
         time.sleep(dt)
-    stop_combined_data_thread()
     print(f"[forefoot {device_ip}] Samples collected: {len(ax_list)}")
 
     distance_meters = round(estimate_distance_from_ax(ax_list,), 3)

--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -376,7 +376,7 @@
       resetBalanceUI();
       startCountdown();
 
-      const response = await fetch("/button_click", { method: "POST", signal });
+      const response = await fetch(window.withGroupQuery("/button_click"), { method: "POST", signal });
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.message || "Unable to start balancing.");

--- a/web_page/templates/foreWalk.html
+++ b/web_page/templates/foreWalk.html
@@ -308,7 +308,7 @@
     }
 
     resetWalkUI();
-    const response = await fetch("/start_forefoot", { method: "POST", signal });
+    const response = await fetch(window.withGroupQuery("/start_forefoot"), { method: "POST", signal });
     const data = await response.json();
     if (!response.ok) {
       throw new Error(data.message || "Unable to start forefoot walk.");

--- a/web_page/templates/jump.html
+++ b/web_page/templates/jump.html
@@ -361,7 +361,7 @@
 
       resetJumpUI();
 
-      const response = await fetch('/start_jump', { signal });
+      const response = await fetch(window.withGroupQuery('/start_jump'), { signal });
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.message || "Unable to start jumping.");

--- a/web_page/templates/precision.html
+++ b/web_page/templates/precision.html
@@ -440,7 +440,7 @@
       }
 
       resetPrecisionUI();
-      const response = await fetch("/start_precision_trainer", { signal });
+      const response = await fetch(window.withGroupQuery("/start_precision_trainer"), { signal });
       if (!response.ok) {
         const data = await response.json();
         throw new Error(data.message || "Unable to start precision.");

--- a/web_page/templates/reaction.html
+++ b/web_page/templates/reaction.html
@@ -309,7 +309,7 @@
       }
 
       resetReactionUI();
-      const response = await fetch("/start_reaction", { signal });
+      const response = await fetch(window.withGroupQuery("/start_reaction"), { signal });
       const data = await response.json();
       if (!response.ok) {
         throw new Error(data.message || "Unable to start reaction.");


### PR DESCRIPTION
## Summary

Two follow-on bugs from PR #33 prevented running activities on two boards at the same time. Reported user symptom: *"if one is running, the other one would stop immediately after I click start"* on precision.

### Bug 1 — shared Flask session cookie

`require_selected_group()` resolved the target board from the server-side session cookie. Two browser tabs in the same browser share that cookie, so clicking Start in tab B could route the request to whichever group tab A had last selected — bumping tab A's session counter and instantly killing its in-flight worker. The fix reads `group_id` from the request itself (query / form / JSON) first, falling back to the session only for legacy single-board pages. Each tab's Start fetch now wraps the URL with the existing `withGroupQuery(...)` helper.

### Bug 2 — worker-side `stop_combined_data_thread()`

`run_precision_trainer` had `finally: stop_combined_data_thread()`, and `start_forefoot` did the same on completion / heel-touchdown. When the first board finished, the shared UDP listener was torn down for *every* other board still mid-activity — they lost their sensor stream and silently stalled. The thread is now stopped only by `/stop_data` (the global panic button).

## Files

- [web_page/app.py](https://github.com/SherimaX/SonicSole/blob/claude/upbeat-sanderson-615fee/web_page/app.py) — new `_group_id_from_request()` helper, `require_selected_group()` rewrite, removed worker-side UDP teardowns.
- `web_page/templates/{jump,balance,reaction,precision,foreWalk}.html` — wrap each `/start_*` fetch with `withGroupQuery(...)`.

No backend session/cookie behavior changes for legacy single-board flow.

## Test plan

- [ ] Restart the dev server (`python app.py` in `web_page/`) and hard-refresh both browser tabs.
- [ ] Open Group 1 + Group 2 in two tabs of the same browser. Start precision in both — both meters update independently for the full 5 s and finish with their own scores.
- [ ] Repeat with jump, balance, reaction, forefoot walk in arbitrary pairings.
- [ ] Single-board legacy flow: open one tab on `/precision`, run all activities sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)