### PR TITLE
Restore -lpthread in Makefile (audio module needs it)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX := g++
 CPPFLAGS := -MMD -MP
 CXXFLAGS := -std=c++17
-LDLIBS := -lwiringPi
+LDLIBS := -lwiringPi -lpthread
 
 TARGET := SonicSole_RPi
 BUILD_DIR := build/sonicsole_rpi


### PR DESCRIPTION
## Summary

PR #38 dropped \`-lpthread\` from \`LDLIBS\` along with the IMU background thread, but \`SonicSole_Audio.cpp\` also uses \`std::thread\` (for non-blocking beep playback). Pi build now fails to link:

\`\`\`
/usr/bin/ld: build/sonicsole_rpi/SonicSole_Audio.o: undefined reference to symbol 'pthread_create@@GLIBC_2.4'
/usr/bin/ld: //lib/arm-linux-gnueabihf/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:23: SonicSole_RPi] Error 1
\`\`\`

One-line fix: put \`-lpthread\` back.

## Test plan

- [ ] On a Pi: \`git pull && make clean && make\` — links cleanly.
- [ ] \`sudo systemctl restart sonicsole.service\` — service comes up active (running).