### PR TITLE
Fix scoreboard mis-routing across tabs; add /scoreboard admin buttons

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -2768,6 +2768,34 @@ def pc_scoreboard_data(board_key):
     })
 
 
+def _clear_all_activity_results():
+    for store, lock in (
+        (jump_results, jump_results_lock),
+        (balance_results, balance_results_lock),
+        (reaction_results, reaction_results_lock),
+        (precision_results, precision_results_lock),
+        (forefoot_results, forefoot_results_lock),
+    ):
+        with lock:
+            store.clear()
+
+
+@app.route('/scoreboard/load_example_data', methods=['POST'])
+def scoreboard_load_example_data():
+    for board_key in LEADERBOARD_CONFIG:
+        write_leaderboard_rows(board_key, DUMMY_LEADERBOARD_ROWS[board_key])
+    _clear_all_activity_results()
+    return jsonify({"status": "ok"})
+
+
+@app.route('/scoreboard/reset_all_data', methods=['POST'])
+def scoreboard_reset_all_data():
+    for board_key in LEADERBOARD_CONFIG:
+        write_leaderboard_rows(board_key, [])
+    _clear_all_activity_results()
+    return jsonify({"status": "ok"})
+
+
 @app.route('/bScoreboard')
 def b_scoreboard():
     return render_template(
@@ -3026,17 +3054,31 @@ def disconnect_group_device():
     )
 
 
-def _resolve_submit_device_ip():
-    """Resolve the device IP whose score should be submitted from this request."""
-    payload = request.form
-    device_ip, _, _ = resolve_group_id_to_device_ip(payload.get("group_id"))
-    return device_ip
+def _resolve_submit_target():
+    """Resolve which group's score should be persisted from this request.
+
+    Returns (device_ip, group_label, error_response_or_None). Both the IP and
+    the label come from the form's `group_id` so the row that gets appended is
+    bound to the same group the page was rendered for. Falling back to the
+    session label here would let a second tab's group selection silently
+    relabel scores submitted from this tab.
+    """
+    device_ip, group, error_message = resolve_group_id_to_device_ip(request.form.get("group_id"))
+    if error_message:
+        return "", "", (jsonify({"status": "error", "message": error_message}), 400)
+    if group is None:
+        return "", "", (
+            jsonify({"status": "error", "message": "Please select a group before submitting the score."}),
+            400,
+        )
+    return device_ip, group["label"], None
 
 
 @app.route('/submitB', methods=['POST'])
 def submitB():
-    submitted_name = get_group_name_from_request("group_name")
-    device_ip = _resolve_submit_device_ip()
+    device_ip, submitted_name, error = _resolve_submit_target()
+    if error:
+        return error
     entry = per_board_get(balance_results, balance_results_lock, device_ip, default_balance_entry)
     append_leaderboard_row("balance", submitted_name, entry.get("total_time", "0"))
     return jsonify({"status": "Group name submitted successfully"})
@@ -3044,16 +3086,18 @@ def submitB():
 
 @app.route('/submitR', methods=['POST'])
 def submitR():
-    submitted_name = get_group_name_from_request("group_name")
-    device_ip = _resolve_submit_device_ip()
+    device_ip, submitted_name, error = _resolve_submit_target()
+    if error:
+        return error
     entry = per_board_get(reaction_results, reaction_results_lock, device_ip, default_reaction_entry)
     append_leaderboard_row("reaction", submitted_name, entry.get("reaction_time", 0))
     return jsonify({"status": "Group name submitted successfully"})
 
 @app.route('/submitW', methods=['POST'])
 def submitW():
-    submitted_name = get_group_name_from_request("group_name")
-    device_ip = _resolve_submit_device_ip()
+    device_ip, submitted_name, error = _resolve_submit_target()
+    if error:
+        return error
     entry = per_board_get(forefoot_results, forefoot_results_lock, device_ip, default_forefoot_entry)
     append_leaderboard_row("walk", submitted_name, entry.get("distance_meters", 0))
     return jsonify({"status": "Group name submitted successfully"})
@@ -3061,16 +3105,18 @@ def submitW():
 
 @app.route('/submitP', methods=['POST'])
 def submitP():
-    submitted_name = get_group_name_from_request("group_name")
-    device_ip = _resolve_submit_device_ip()
+    device_ip, submitted_name, error = _resolve_submit_target()
+    if error:
+        return error
     entry = per_board_get(precision_results, precision_results_lock, device_ip, default_precision_entry)
     append_leaderboard_row("precision", submitted_name, entry.get("error_percent", 0))
     return jsonify({"status": "Group name submitted successfully"})
 
 @app.route('/submitJ', methods=['POST'])
 def submitJ():
-    submitted_name = get_group_name_from_request("group_name")
-    device_ip = _resolve_submit_device_ip()
+    device_ip, submitted_name, error = _resolve_submit_target()
+    if error:
+        return error
     entry = per_board_get(jump_results, jump_results_lock, device_ip, default_jump_entry)
     append_leaderboard_row("jump", submitted_name, entry.get("height", 0.0))
     return jsonify({"status": "Group name submitted successfully"})

--- a/web_page/templates/scoreboard.html
+++ b/web_page/templates/scoreboard.html
@@ -32,6 +32,39 @@
 
     .pg-scoreboard-titlebar .pg-header-nav {
       width: auto;
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    .pg-scoreboard-admin-btn {
+      appearance: none;
+      border: 1px solid rgba(0, 0, 0, 0.16);
+      background: rgba(255, 255, 255, 0.7);
+      color: inherit;
+      font: inherit;
+      padding: 6px 14px;
+      border-radius: 999px;
+      cursor: pointer;
+    }
+
+    .pg-scoreboard-admin-btn:hover {
+      background: rgba(var(--activity-rgb), 0.16);
+    }
+
+    .pg-scoreboard-admin-btn--danger {
+      border-color: rgba(180, 30, 30, 0.4);
+      color: #8a1f1f;
+    }
+
+    .pg-scoreboard-admin-btn--danger:hover {
+      background: rgba(180, 30, 30, 0.1);
+    }
+
+    .pg-scoreboard-admin-btn[disabled] {
+      opacity: 0.55;
+      cursor: progress;
     }
 
     .pg-scoreboard-table {
@@ -89,6 +122,16 @@
     <div class="pg-scoreboard-titlebar">
       <h1>{{ scoreboard_activity.title }}</h1>
       <div class="pg-header-nav">
+        <button
+          type="button"
+          class="pg-scoreboard-admin-btn"
+          id="loadExampleDataBtn"
+        >Load example data</button>
+        <button
+          type="button"
+          class="pg-scoreboard-admin-btn pg-scoreboard-admin-btn--danger"
+          id="resetAllDataBtn"
+        >Reset all data</button>
         <a class="pg-ghost-link" href="{{ url_for('home') }}">Home</a>
       </div>
     </div>
@@ -325,6 +368,41 @@
       if (document.visibilityState === "visible") {
         pollScoreboard();
       }
+    });
+
+    async function postAdminAction(url, button, originalLabel, busyLabel) {
+      button.disabled = true;
+      const previousLabel = button.textContent;
+      button.textContent = busyLabel;
+      try {
+        const response = await fetch(url, { method: "POST", cache: "no-store" });
+        if (!response.ok) {
+          throw new Error("Server returned " + response.status);
+        }
+        await pollScoreboard();
+      } catch (error) {
+        alert((originalLabel || "Action") + " failed: " + (error.message || error));
+      } finally {
+        button.disabled = false;
+        button.textContent = previousLabel;
+      }
+    }
+
+    const loadExampleDataBtn = document.getElementById("loadExampleDataBtn");
+    const resetAllDataBtn = document.getElementById("resetAllDataBtn");
+
+    loadExampleDataBtn.addEventListener("click", () => {
+      if (!confirm("Replace every scoreboard with example data? This overwrites all current scores.")) {
+        return;
+      }
+      postAdminAction("/scoreboard/load_example_data", loadExampleDataBtn, "Load example data", "Loading…");
+    });
+
+    resetAllDataBtn.addEventListener("click", () => {
+      if (!confirm("Reset every scoreboard to empty? This deletes all current scores and cannot be undone.")) {
+        return;
+      }
+      postAdminAction("/scoreboard/reset_all_data", resetAllDataBtn, "Reset all data", "Resetting…");
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- **Bug fix:** scores submitted from one tab could be filed under another tab's group when both tabs shared one Flask session. `/submitX` handlers resolved the score *value* from `form.group_id` but resolved the CSV *label* from `session["selected_group_id"]` (via `get_group_name_from_request`'s session fallback). After tab B selects a different group, the session cookie holds B's id, and tab A's next submit is appended with B's label. Both fields now come from the same `form.group_id` lookup via the new `_resolve_submit_target()` helper.
- **New admin controls on `/scoreboard`:** two header buttons — *Load example data* (seeds `DUMMY_LEADERBOARD_ROWS` into all five CSVs) and *Reset all data* (truncates all five CSVs + clears in-memory result dicts under their locks). Each button is guarded by a `confirm()` dialog. Backed by new `POST /scoreboard/load_example_data` and `POST /scoreboard/reset_all_data` endpoints. Buttons live in `scoreboard.html` only — they do not appear on the legacy `bScoreboard`/`jScoreboard`/etc. pages.

## Why
- The mis-routing bug was reported as "scores from one group ending up saved under another." It surfaces in the common multi-tab demo flow where each operator picks their own group in a separate tab.
- Reset/load buttons let the operator preload demo rows for testing UI behavior and then wipe everything before a real session — previously this required hand-editing the `SonicSole*.txt` files.

## Test plan
- [x] Local syntax check on `app.py`.
- [x] Started Flask on port 5099, hit `POST /scoreboard/reset_all_data` → all five CSVs truncated to 0 bytes.
- [x] Hit `POST /scoreboard/load_example_data` → CSVs rewritten with the dummy rows from `DUMMY_LEADERBOARD_ROWS`.
- [x] Reproduced the cross-tab bug scenario: `POST /select_group {group_id: group_2}`, then `POST /submitJ group_id=group_1`. Last row in `SonicSoleJump.txt` was `Group 1,0.0` (with the fix; it would have been `Group 2,...` before).
- [ ] Click both buttons in the browser at `http://127.0.0.1:5001/scoreboard` and confirm the table refreshes.
- [ ] Run a real activity from one tab while a second tab has another group selected, then submit, and confirm the new row carries the originating tab's group label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)