### PR TITLE
Suppress sample-history fallback in group overlay after reset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ web_page/static/video8.mp4
 
 build/
 SonicSole_RPi
+
+# Local scoreboard state — created when the operator hits "Reset all data".
+.scoreboard_no_sample

--- a/web_page/app.py
+++ b/web_page/app.py
@@ -752,7 +752,16 @@ def history_has_attempts(history_sections):
     return any((section.get("attempt_count") or 0) > 0 for section in history_sections)
 
 
+SAMPLE_HISTORY_SUPPRESS_MARKER = os.path.join(PROJECT_ROOT, ".scoreboard_no_sample")
+
+
+def sample_history_fallback_suppressed():
+    return os.path.exists(SAMPLE_HISTORY_SUPPRESS_MARKER)
+
+
 def load_sample_group_history(group):
+    if sample_history_fallback_suppressed():
+        return None
     sample_path = get_sample_group_history_path(group)
     if not sample_path or not os.path.exists(sample_path):
         return None
@@ -2785,6 +2794,10 @@ def scoreboard_load_example_data():
     for board_key in LEADERBOARD_CONFIG:
         write_leaderboard_rows(board_key, DUMMY_LEADERBOARD_ROWS[board_key])
     _clear_all_activity_results()
+    try:
+        os.remove(SAMPLE_HISTORY_SUPPRESS_MARKER)
+    except FileNotFoundError:
+        pass
     return jsonify({"status": "ok"})
 
 
@@ -2793,6 +2806,8 @@ def scoreboard_reset_all_data():
     for board_key in LEADERBOARD_CONFIG:
         write_leaderboard_rows(board_key, [])
     _clear_all_activity_results()
+    with open(SAMPLE_HISTORY_SUPPRESS_MARKER, "w") as marker:
+        marker.write("")
     return jsonify({"status": "ok"})
 
 


### PR DESCRIPTION
## Summary
Follow-up to #40. After clicking **Reset all data**, opening any group's per-group history overlay still showed the bundled sample rows from `web_page/static/sample_group_history/group_*.json`, because `/group_history_data` falls back to that sample JSON whenever the live CSV history is empty.

This PR persists the operator's reset intent with a marker file at `<PROJECT_ROOT>/.scoreboard_no_sample`:

- **Reset all data** creates the marker.
- **Load example data** removes the marker.
- `load_sample_group_history()` short-circuits to `None` whenever the marker exists, so empty CSVs render as empty overlays (not as sample data).

The marker is added to `.gitignore` so a local reset doesn't leak into commits.

## Why
The reset button's purpose is "wipe demo state before a real session." Without this change, the wipe was incomplete — operators would open Group N's overlay and still see fake rows.

## Why the marker isn't auto-cleared by real sensor submissions
A group that already has real attempts doesn't need the marker — `history_has_attempts(history)` is true, so `load_sample_group_history` is never called for it. The marker matters for groups that haven't played yet during a live session: keeping it suppressed prevents fake sample rows from re-appearing the moment any unscored group's overlay is opened mid-session.

## Test plan
- [x] Hit `POST /scoreboard/reset_all_data`, then `GET /group_history_data?group_id=group_1` → `source: live`, 0 attempts (was 5 sample attempts before the fix).
- [x] Hit `POST /scoreboard/load_example_data` → marker removed; overlay shows the dummy CSV rows (one per board).
- [x] Confirmed marker is created/removed at the expected path and is gitignored.
- [ ] Run a real activity end-to-end after a reset and verify the originating group's overlay shows the live row, while an unscored group's overlay stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)