### PR TITLE
Balance: drop pressure from main status, keep heel/fore debug below

### DIFF
--- a/web_page/templates/balance.html
+++ b/web_page/templates/balance.html
@@ -307,17 +307,6 @@
       setBalanceStatusHTML("<strong>Getting Ready</strong>");
     }
 
-    function renderPressureLive(pressureSum, threshold) {
-      const sumDisplay = Number.isFinite(pressureSum) ? pressureSum : 0;
-      const thresholdDisplay = Number.isFinite(threshold) ? threshold : 0;
-      setBalanceStatusHTML(
-        `<div class="pg-status-stacked">` +
-        `<strong>Pressure: ${sumDisplay}</strong>` +
-        `<span class="pg-status-sub">Threshold: ${thresholdDisplay}</span>` +
-        `</div>`
-      );
-    }
-
     function fetchData() {
       fetch(window.withGroupQuery("/balancing"))
         .then((response) => response.json())
@@ -328,7 +317,7 @@
               `<div class="pg-status-stacked"><strong>Try again</strong><span class="pg-status-sub">${data.reason || "Measurement failed"}</span></div>`
             );
           } else if (data.status === "measuring") {
-            renderPressureLive(data.pressure_sum, data.threshold);
+            setBalanceStatusHTML("<strong>Measuring</strong>");
           } else if (!toggleActive && !data.done && String(data.data) === "0") {
             setBalanceReadyState();
           } else {


### PR DESCRIPTION
## Summary
- Removed the live "Pressure: X / Threshold: Y" readout from the main status square in the phone's group balancing activity; during measuring it now shows just "Measuring".
- The heel/fore live pressure debug panel rendered below the status square (shared across balance, precision, reaction, and jump via `_live_pressure_debug.html`) is unchanged, so the bottom-of-square pressure remains for all activities.

## Test plan
- [ ] Open `/balance` on the phone, select a group, and start the activity. Confirm the main square shows "Getting Ready" → "Measuring" → "X seconds" without ever surfacing "Pressure" / "Threshold" text.
- [ ] Verify the heel/fore debug strip below the square still updates while the activity runs.
- [ ] Spot-check `/precision`, `/reaction`, and `/jump` to confirm their bottom-of-square heel/fore readouts are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)