### PR TITLE
Jump: cap airtime to reject foot-lift cheats

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1075,6 +1075,14 @@ ACTIVITY_THRESHOLD_SPEC = {
                 "max": 4095,
                 "step": 1,
             },
+            "max_airtime_seconds": {
+                "label": "Maximum airtime (s)",
+                "help": "Jumps with airtime above this are rejected as unrealistic (likely a foot lift, not a real jump). 0.4s ≈ 20 cm jump height.",
+                "default": 0.4,
+                "min": 0.0,
+                "max": 5.0,
+                "step": 0.05,
+            },
         },
     },
     "balance": {
@@ -2032,6 +2040,18 @@ def start_jump():
     airtime, height, was_cancelled = get_airtime_and_height(session_id, device_ip)
     if was_cancelled:
         return jsonify({'status': 'cancelled'})
+
+    max_airtime = get_threshold("jump", "max_airtime_seconds")
+    if airtime > max_airtime:
+        print(f"[jump {device_ip}] Airtime {airtime:.3f}s above max {max_airtime}s — try again")
+        reset_jump_state(device_ip=device_ip, cancel_session=True)
+        return jsonify({
+            'status': 'too_long',
+            'message': 'Try again — airtime too long to be a real jump.',
+            'airtime': airtime,
+            'max_airtime': max_airtime,
+        })
+
     per_board_set(jump_results, jump_results_lock, device_ip, {
         "airtime": airtime,
         "height": height,

--- a/web_page/templates/jump.html
+++ b/web_page/templates/jump.html
@@ -371,6 +371,14 @@
       if (data.status === "cancelled") {
         return;
       }
+      if (data.status === "too_long") {
+        stopJumpWaitingAnimation();
+        jumpStatus.innerHTML = `<strong>Try Again</strong>`;
+        if (jumpActivityToggle) {
+          jumpActivityToggle.setActive(false);
+        }
+        return;
+      }
       startJumpWaitingAnimation();
       pollJumpData();
     }


### PR DESCRIPTION
## Summary

- Pressure-only jump detection in `/start_jump` accepts any airtime, so a user who just lifts their foot for 2s gets reported as a ~4.9 m jump.
- Add a runtime-tunable `max_airtime_seconds` threshold (default **0.4s ≈ 20 cm**) on the `/settings` page.
- If the measured airtime exceeds the max, the server returns `{"status": "too_long", ...}`, clears jump state, and the jump UI shows **"Try Again"** with the Start button re-armed.

## Why

Lifting a foot looks identical to jumping from a pressure standpoint, but produces unrealistic airtimes. Capping max airtime is the cheapest defense against that failure mode and lets operators tune the ceiling per study/cohort without a restart.

## Files

- [web_page/app.py](web_page/app.py) — adds `max_airtime_seconds` to `ACTIVITY_THRESHOLD_SPEC["jump"]`; adds the post-measurement check in `start_jump()`.
- [web_page/templates/jump.html](web_page/templates/jump.html) — handles the new `too_long` response by showing "Try Again" and resetting the activity toggle.

## Test plan

- [ ] Stand on insole, jump normally below 20 cm → height reported as before.
- [ ] Stand on insole, lift foot for >0.4s and replant → UI shows "Try Again", no result stored, Start button re-armed.
- [ ] Visit `/settings`, change `Maximum airtime (s)` to 0.6, save → next jump cap is 0.6s without server restart.
- [ ] Cancel mid-jump (press Stop while in air) → behavior unchanged (still returns `cancelled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)