### PR TITLE
Center activity status square on phone pages viewed at desktop width

### DIFF
--- a/web_page/static/playground-theme.css
+++ b/web_page/static/playground-theme.css
@@ -248,6 +248,12 @@ body.pg-screen.pg-activity.pg-phone-app .pg-activity-card .pg-actions {
   padding-top: 0;
 }
 
+body.pg-screen.pg-activity.pg-phone-app .pg-status-grid > .pg-activity-status-box--square:only-child {
+  grid-column: 1 / -1;
+  justify-self: center;
+  width: min(100%, 360px) !important;
+}
+
 body.pg-screen.pg-activity.pg-phone-app .pg-activity-stage.pg-overflows-y {
   padding-bottom: calc(138px + var(--pg-phone-bottom-safe-space));
 }


### PR DESCRIPTION
## Summary
- On phone activity pages (jump, balance, reaction, precision) viewed above the 720px breakpoint, the colored status square was sitting in column 1 of the 2-column `.pg-status-grid` and looked left-aligned.
- Added a single CSS rule in [playground-theme.css](web_page/static/playground-theme.css) that, for `body.pg-phone-app` only, makes a sole `.pg-activity-status-box--square` span both grid columns, caps it at `360px`, and applies `justify-self: center`.
- `:only-child` guard means foreWalk-style pages with two status boxes are untouched; `min(100%, 360px)` resolves to 100% on phone-width viewports, so mobile rendering is unchanged.

## Test plan
- [x] `/phone/group1/jump` at 1280×800: square is 360×360, centered in the 514px-wide grid (verified via `preview_inspect` + screenshot).
- [x] `/phone/group1/jump` at 375×812: square fills the card width as before (1-column grid via existing `max-width: 720px` media query, 360px cap doesn't kick in).
- [x] `:only-child` selector keeps two-status-box layouts (foreWalk) on the existing 2-column behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)