### PR TITLE
Update default board IP mapping to 192.168.0.101–105

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -38,11 +38,11 @@ GROUP_SLOTS = [
 ]
 GROUP_OPTIONS_BY_ID = {group["id"]: group for group in GROUP_SLOTS}
 DEFAULT_GROUP_DEVICE_IPS = {
-    1: "192.168.2.5",
-    2: "192.168.2.7",
-    3: "192.168.2.8",
-    4: "192.168.2.9",
-    5: "192.168.2.10",
+    1: "192.168.0.101",
+    2: "192.168.0.102",
+    3: "192.168.0.103",
+    4: "192.168.0.104",
+    5: "192.168.0.105",
 }
 HARDWARE_PING_TIMEOUT_SECONDS = 1.0
 


### PR DESCRIPTION
## Summary
- Remap default board IPs in `DEFAULT_GROUP_DEVICE_IPS` so boards 1–5 resolve to `192.168.0.101`–`192.168.0.105` to match the current network configuration.

## Test plan
- [ ] Confirm boards 1–5 ping at the new addresses on the deployed network.
- [ ] Verify the web app's hardware status reflects the updated IPs without manual override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)