### PR TITLE
Reaction: reuse the status box as the cue, drop the extra div

### DIFF
--- a/web_page/templates/reaction.html
+++ b/web_page/templates/reaction.html
@@ -160,50 +160,19 @@
       animation: glow 1s infinite alternate;
     }
 
-    /* Reaction visual cue box */
-    .reaction-cue {
-      width: min(72%, 360px);
-      aspect-ratio: 1 / 1;
-      margin: 18px auto 4px;
-      border-radius: 24px;
-      border: 4px solid rgba(216, 134, 175, 0.85);
-      background: transparent;
-      box-shadow:
-        inset 0 0 0 1px rgba(255, 255, 255, 0.04),
-        0 14px 28px rgba(0, 0, 0, 0.35);
+    /* Status box reused as the reaction cue: at the GO moment we flip it from
+       the default pink-tinted transparent panel to a solid pink fill. */
+    #statusBox {
       transition: background-color 80ms linear, box-shadow 80ms linear, border-color 120ms ease;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      color: rgba(216, 134, 175, 0.85);
-      font-family: "Impact", "Arial Black", sans-serif;
-      letter-spacing: 0.12em;
-      font-size: 1.6em;
-      text-transform: uppercase;
-      user-select: none;
     }
 
-    .reaction-cue.is-armed {
-      border-color: rgba(216, 134, 175, 0.6);
-      color: rgba(216, 134, 175, 0.55);
-    }
-
-    .reaction-cue.is-fired {
-      background: rgba(216, 134, 175, 0.92);
-      border-color: rgba(216, 134, 175, 1);
-      color: #1a0a14;
+    #statusBox.is-fired {
+      background: rgba(var(--activity-rgb), 0.92) !important;
+      border-color: rgba(var(--activity-rgb), 1) !important;
+      color: #1a0a14 !important;
       box-shadow:
-        0 0 0 6px rgba(216, 134, 175, 0.18),
-        0 18px 38px rgba(216, 134, 175, 0.35);
-    }
-
-    .reaction-cue.is-error {
-      border-color: rgba(255, 92, 92, 0.85);
-      color: rgba(255, 92, 92, 0.85);
-    }
-
-    .reaction-cue__label {
-      pointer-events: none;
+        0 0 0 6px rgba(var(--activity-rgb), 0.18),
+        0 18px 38px rgba(var(--activity-rgb), 0.35) !important;
     }
 
     /* Modal styling */
@@ -288,10 +257,6 @@
         {% include '_activity_status_box.html' %}
       </div>
 
-      <div id="reactionCue" class="reaction-cue" aria-live="polite">
-        <span class="reaction-cue__label" id="reactionCueLabel">Press Start</span>
-      </div>
-
       {% include '_live_pressure_debug.html' %}
 
       <div class="buttons pg-actions">
@@ -347,24 +312,14 @@
     let cuePerfMs = 0;
     let phase = "idle";
 
-    function setStatus(text) {
-      document.getElementById("statusBox").innerText = text;
-    }
-
-    function setCueState(state, label) {
-      const cue = document.getElementById("reactionCue");
-      cue.classList.remove("is-armed", "is-fired", "is-error");
-      if (state) {
-        cue.classList.add(state);
-      }
-      if (label !== undefined) {
-        document.getElementById("reactionCueLabel").innerText = label;
-      }
+    function setStatus(text, { fired = false } = {}) {
+      const box = document.getElementById("statusBox");
+      box.innerText = text;
+      box.classList.toggle("is-fired", fired);
     }
 
     function setReactionReadyState() {
       setStatus("Getting Ready");
-      setCueState(null, "Press Start");
       phase = "idle";
     }
 
@@ -425,8 +380,7 @@
       }
       phase = "reacting";
       cuePerfMs = performance.now();
-      setCueState("is-fired", "GO!");
-      setStatus("Press now!");
+      setStatus("Press now!", { fired: true });
 
       reactionTimeoutId = setTimeout(() => {
         reactionTimeoutId = null;
@@ -435,7 +389,6 @@
         }
         phase = "timeout";
         clearReactionTimers();
-        setCueState("is-error", "Too slow");
         setStatus("No press detected. Try again.");
         reportOutcome("timeout").catch(() => {});
         if (reactionActivityToggle) {
@@ -447,7 +400,6 @@
     function handlePressDuringWait() {
       phase = "tooEarly";
       clearReactionTimers();
-      setCueState("is-error", "False start");
       setStatus("Invalid attempt. You moved too early.");
       reportOutcome("too_early").catch(() => {});
       if (reactionActivityToggle) {
@@ -520,7 +472,6 @@
       const maxDelaySec = Number(data.max_delay_sec) || FALLBACK_MAX_DELAY_SEC;
 
       phase = "waiting";
-      setCueState("is-armed", "Wait…");
       setStatus("Wait for the pink cue");
 
       const delayMs = pickInRange(minDelaySec, maxDelaySec) * 1000;


### PR DESCRIPTION
## Summary
Follow-up to [#46](https://github.com/SherimaX/SonicSole/pull/46): the visual cue lived in a separate `.reaction-cue` `<div>` with its own `Impact` font and styling. This PR removes that element and reuses the existing `#statusBox` (which is already rendered as a transparent pink-bordered panel for the reaction activity via `--activity-rgb`) as the cue itself. Same font and layout as every other activity's status box.

## What changed
- Drop the `#reactionCue` element from `web_page/templates/reaction.html`.
- Drop its `.reaction-cue*` CSS rules (custom border, Impact font, error states).
- Add a small `#statusBox.is-fired` rule that flips the existing status box to a solid pink fill at the GO moment.
- Collapse the JS: `setStatus(text, { fired })` now toggles the `is-fired` class on the status box and updates its text. Removed `setCueState` and the standalone cue label element.

## Notes for reviewers
- No changes to `app.py` or any other activity. This is purely a UI cleanup on the reaction page.
- Rebased onto current `main`, which includes [#47](https://github.com/SherimaX/SonicSole/pull/47) (default board IP mapping) — only one commit ahead.

## Test plan
- [ ] Open `/phone/<group>/reaction` → confirm the page no longer renders an extra purple/pink box; only the existing status square is visible.
- [ ] Click Start → status square shows "Wait for the pink cue" with the default subtle pink tint.
- [ ] After 3–6 s, the status square fills solid pink with "Press now!".
- [ ] Press the insole → reaction time appears in the same square; submit form shows up; scoreboard row gets a real number.
- [ ] Press too early or wait past the react window → square returns to neutral with the appropriate error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)