### PR TITLE
Precision: heel sensor by default, sensor selectable in Settings

### DIFF
--- a/web_page/app.py
+++ b/web_page/app.py
@@ -1139,8 +1139,18 @@ ACTIVITY_THRESHOLD_SPEC = {
     },
     "precision": {
         "label": "Precision",
-        "help": "Force range and capture window for the precision trainer.",
+        "help": "Force range, capture window, and sensor used by the precision trainer.",
         "fields": {
+            "sensor": {
+                "label": "Sensor",
+                "help": "Which pressure sensor the trainer reads. Heel gives the most precise signal for most users.",
+                "type": "choice",
+                "default": "heel",
+                "options": [
+                    {"value": "heel", "label": "Heel"},
+                    {"value": "forefoot", "label": "Forefoot"},
+                ],
+            },
             "force_max": {
                 "label": "Max force (counts)",
                 "help": "Pressure value that maps to 100% on the precision dial.",
@@ -1159,6 +1169,11 @@ ACTIVITY_THRESHOLD_SPEC = {
             },
         },
     },
+}
+
+PRECISION_SENSOR_KEYS = {
+    "heel": "heel_pressure",
+    "forefoot": "fore_pressure",
 }
 
 activity_thresholds_lock = threading.Lock()
@@ -1276,6 +1291,7 @@ def default_precision_entry():
     return {
         "status": "idle",
         "max_force": get_threshold("precision", "force_max"),
+        "sensor": get_threshold("precision", "sensor"),
         "target_percent": 0,
         "target_force": 0,
         "current_force": 0,
@@ -2372,6 +2388,7 @@ def precision_trainer_status():
         current_force=entry.get("current_force", 0),
         current_percent=entry.get("current_percent", 0),
         max_force=entry.get("max_force", precision_force_max),
+        sensor=entry.get("sensor", get_threshold("precision", "sensor")),
     )
 
 def run_precision_trainer(session_id, device_ip):
@@ -2381,6 +2398,8 @@ def run_precision_trainer(session_id, device_ip):
     start_combined_data_thread()
     precision_force_max = get_threshold("precision", "force_max")
     capture_seconds = get_threshold("precision", "capture_seconds")
+    sensor = get_threshold("precision", "sensor")
+    sensor_key = PRECISION_SENSOR_KEYS.get(sensor, PRECISION_SENSOR_KEYS["heel"])
     target_percent = random.choice(PRECISION_TARGET_PERCENTS)
     target_force = round((target_percent / 100.0) * precision_force_max)
     per_board_update(
@@ -2390,6 +2409,7 @@ def run_precision_trainer(session_id, device_ip):
         default_precision_entry,
         status="measuring",
         max_force=precision_force_max,
+        sensor=sensor,
         target_percent=target_percent,
         target_force=target_force,
         current_force=0,
@@ -2404,7 +2424,7 @@ def run_precision_trainer(session_id, device_ip):
         if not is_activity_session_active(device_ip, "precision", session_id):
             return
         snapshot = read_sensor_for_ip(device_ip)
-        current_force = get_precision_force_value(snapshot["fore_pressure"])
+        current_force = get_precision_force_value(snapshot[sensor_key])
         current_percent = round((current_force / precision_force_max) * 100, 1)
         per_board_update(
             precision_results,
@@ -2420,7 +2440,7 @@ def run_precision_trainer(session_id, device_ip):
         return
 
     snapshot = read_sensor_for_ip(device_ip)
-    measured_force = get_precision_force_value(snapshot["fore_pressure"])
+    measured_force = get_precision_force_value(snapshot[sensor_key])
     measured_percent = round((measured_force / precision_force_max) * 100, 1)
     precision_error_value = abs(measured_percent - target_percent)
     per_board_update(
@@ -2450,6 +2470,7 @@ def precision_trainer_results():
         error_percent=entry.get("error_percent", 0.0),
         target_percent=entry.get("target_percent", 0),
         max_force=entry.get("max_force", precision_force_max),
+        sensor=entry.get("sensor", get_threshold("precision", "sensor")),
     )
 
 # fore walk
@@ -2643,16 +2664,22 @@ def _build_threshold_view():
     for activity_slug, details in ACTIVITY_THRESHOLD_SPEC.items():
         fields = []
         for field_slug, field_spec in details["fields"].items():
-            fields.append({
+            field_type = field_spec.get("type", "number")
+            entry = {
                 "slug": field_slug,
                 "label": field_spec["label"],
                 "help": field_spec.get("help", ""),
+                "type": field_type,
                 "default": field_spec["default"],
-                "min": field_spec["min"],
-                "max": field_spec["max"],
-                "step": field_spec["step"],
                 "value": get_threshold(activity_slug, field_slug),
-            })
+            }
+            if field_type == "choice":
+                entry["options"] = list(field_spec.get("options", []))
+            else:
+                entry["min"] = field_spec["min"]
+                entry["max"] = field_spec["max"]
+                entry["step"] = field_spec["step"]
+            fields.append(entry)
         activities.append({
             "slug": activity_slug,
             "label": details["label"],
@@ -2691,6 +2718,17 @@ def update_thresholds_api():
         for field_slug, raw_value in fields.items():
             field_spec = spec["fields"].get(field_slug)
             if field_spec is None:
+                continue
+            field_type = field_spec.get("type", "number")
+            if field_type == "choice":
+                allowed = {opt["value"] for opt in field_spec.get("options", [])}
+                value = str(raw_value) if raw_value is not None else ""
+                if value not in allowed:
+                    errors.setdefault(activity_slug, {})[field_slug] = (
+                        f"Must be one of: {', '.join(sorted(allowed))}."
+                    )
+                    continue
+                parsed.setdefault(activity_slug, {})[field_slug] = value
                 continue
             try:
                 if isinstance(field_spec["step"], int):

--- a/web_page/templates/precision.html
+++ b/web_page/templates/precision.html
@@ -376,7 +376,7 @@
   {% endif %}
 
   {% set instructions_title = "How to Train Precision" %}
-  {% set instructions_body = "Press down on the forefoot sensor to match the target force shown on the meter. Hold as close to the target as possible — the closer your current force is to the target, the better your score." %}
+  {% set instructions_body = "Press down on the selected sensor (heel by default — change it under Settings → Precision) to match the target force shown on the meter. Hold as close to the target as possible — the closer your current force is to the target, the better your score." %}
   {% include '_instructions_modal.html' %}
 
   {% include '_activity_dock.html' %}
@@ -384,6 +384,12 @@
   <script>
     let pollingInterval = null;
     let precisionActivityToggle = null;
+
+    const SENSOR_LABELS = { heel: "heel", forefoot: "forefoot" };
+
+    function sensorLabel(sensor) {
+      return SENSOR_LABELS[sensor] || "selected";
+    }
 
     function setPrecisionReadyState() {
       document.getElementById("statusBox").innerHTML = "<strong>Getting Ready</strong>";
@@ -453,6 +459,11 @@
       startPolling();
     }
 
+    function setMatchPrompt(sensor) {
+      document.getElementById("statusBox").innerText =
+        `Match the target force using your ${sensorLabel(sensor)} sensor`;
+    }
+
     function startPolling() {
       if (pollingInterval) clearInterval(pollingInterval);
       pollingInterval = setInterval(fetchTrainerStatus, 300);
@@ -474,7 +485,7 @@
           const maxForce = data.max_force || 2000;
 
           if (statusText.includes("measuring")) {
-            messageBox.innerText = "Match the target force";
+            setMatchPrompt(data.sensor);
             setMeterVisibility(true);
             renderForceMeter({
               targetPercent,
@@ -514,7 +525,7 @@
             maxForce: data.max_force || 2000,
           });
           document.getElementById("statusBox").innerHTML = `
-            Captured at 5s<br>
+            Captured at 5s (${sensorLabel(data.sensor)} sensor)<br>
             Target Force: ${Math.round(data.target_force || 0)}<br>
             Measured Force: ${Math.round(data.measured_force || 0)}<br>
             Percent Error: ${(data.error_percent || 0).toFixed(1)}%

--- a/web_page/templates/settings.html
+++ b/web_page/templates/settings.html
@@ -152,7 +152,8 @@
       color: var(--text-subtle);
     }
 
-    .field input[type="number"] {
+    .field input[type="number"],
+    .field select {
       font: inherit;
       font-size: 1rem;
       padding: 8px 10px;
@@ -164,7 +165,8 @@
       transition: border-color 0.2s ease, box-shadow 0.2s ease;
     }
 
-    .field input[type="number"]:focus {
+    .field input[type="number"]:focus,
+    .field select:focus {
       border-color: var(--accent);
       box-shadow: 0 0 0 3px rgba(122, 28, 28, 0.18);
     }
@@ -276,11 +278,22 @@
       {% if activity.fields %}
       <div class="field-grid">
         {% for field in activity.fields %}
-        <div class="field" data-field="{{ field.slug }}">
+        <div class="field" data-field="{{ field.slug }}" data-field-type="{{ field.type }}">
           <label>
             <span>{{ field.label }}</span>
             <span class="field-default">default: {{ field.default }}</span>
           </label>
+          {% if field.type == "choice" %}
+          <select
+            name="{{ activity.slug }}__{{ field.slug }}"
+            data-default="{{ field.default }}"
+            required
+          >
+            {% for option in field.options %}
+            <option value="{{ option.value }}" {% if option.value == field.value %}selected{% endif %}>{{ option.label }}</option>
+            {% endfor %}
+          </select>
+          {% else %}
           <input
             type="number"
             name="{{ activity.slug }}__{{ field.slug }}"
@@ -291,6 +304,7 @@
             data-default="{{ field.default }}"
             required
           />
+          {% endif %}
           {% if field.help %}<p class="field-help">{{ field.help }}</p>{% endif %}
           <p class="field-error" hidden></p>
         </div>
@@ -349,15 +363,19 @@
       });
     }
 
+    function fieldControl(fieldEl) {
+      return fieldEl.querySelector("input[type='number'], select");
+    }
+
     function collectThresholds() {
       const thresholds = {};
       form.querySelectorAll(".activity-card").forEach((card) => {
         const activitySlug = card.dataset.activity;
         const fieldsForActivity = {};
         card.querySelectorAll(".field").forEach((fieldEl) => {
-          const input = fieldEl.querySelector("input[type='number']");
-          if (!input) return;
-          fieldsForActivity[fieldEl.dataset.field] = input.value;
+          const control = fieldControl(fieldEl);
+          if (!control) return;
+          fieldsForActivity[fieldEl.dataset.field] = control.value;
         });
         if (Object.keys(fieldsForActivity).length > 0) {
           thresholds[activitySlug] = fieldsForActivity;
@@ -369,11 +387,12 @@
     function applyValues(activities) {
       activities.forEach((activity) => {
         activity.fields.forEach((field) => {
-          const input = form.querySelector(
-            `.activity-card[data-activity="${activity.slug}"] .field[data-field="${field.slug}"] input`
+          const fieldEl = form.querySelector(
+            `.activity-card[data-activity="${activity.slug}"] .field[data-field="${field.slug}"]`
           );
-          if (input) {
-            input.value = field.value;
+          const control = fieldEl ? fieldControl(fieldEl) : null;
+          if (control) {
+            control.value = field.value;
           }
         });
       });
@@ -410,9 +429,11 @@
 
     resetButton.addEventListener("click", () => {
       clearFieldErrors();
-      form.querySelectorAll("input[type='number'][data-default]").forEach((input) => {
-        input.value = input.dataset.default;
-      });
+      form
+        .querySelectorAll("input[type='number'][data-default], select[data-default]")
+        .forEach((control) => {
+          control.value = control.dataset.default;
+        });
       showToast("Defaults loaded — press Save to apply.");
     });
   </script>


### PR DESCRIPTION
## Summary
- Precision trainer now reads the **heel** pressure sensor by default (was always forefoot).
- Adds a **Sensor** dropdown under Settings → Precision so the operator can switch between Heel and Forefoot at runtime.
- Trainer status/results responses now include the active sensor so the precision page labels which sensor to press ("Match the target force using your heel sensor", "Captured at 5s (heel sensor)").
- Generalizes the settings spec/UI to support non-numeric `choice` fields: validated against the option list, rendered as `<select>`, and included in the Reset-to-defaults flow.

## Why
Heel pressure gives a cleaner, more precise signal for most users running the precision trainer. Making the sensor configurable keeps the forefoot path available without forcing a code change.

## Test plan
- [ ] Open `/settings`, confirm Precision card shows a "Sensor" dropdown with Heel (default) and Forefoot.
- [ ] Save with Heel selected → run `/precision`, status box reads "...using your heel sensor", final summary says "(heel sensor)".
- [ ] Switch to Forefoot, save, re-run → status/summary now reference forefoot, and the meter reacts to forefoot pressure only.
- [ ] Reset-to-defaults restores Sensor → Heel and the numeric fields to their defaults.
- [ ] Submit an invalid sensor value via `POST /api/settings/thresholds` → returns a 400 with a "Must be one of: forefoot, heel." error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)